### PR TITLE
Java 11 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,10 @@
         </license>
     </licenses>
     <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+
         <servlet.tc90.version>4.0.1</servlet.tc90.version>
         <servlet.jsp.tc90.version>2.3.3</servlet.jsp.tc90.version>
         <servlet.el.tc90.version>3.0.0</servlet.el.tc90.version>

--- a/src/main/java/io/atlassian/util/adapter/jakarta/JakartaAdapters.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/JakartaAdapters.java
@@ -33,17 +33,23 @@ public final class JakartaAdapters {
      * </ul>
      */
     public static Object asJakartaIfJavaX(Object delegate) {
-        if (delegate instanceof javax.servlet.ServletRequest cast) {
+        if (delegate instanceof javax.servlet.ServletRequest) {
+            javax.servlet.ServletRequest cast = (javax.servlet.ServletRequest) delegate;
             return asJakarta(cast);
-        } else if (delegate instanceof javax.servlet.ServletResponse cast) {
+        } else if (delegate instanceof javax.servlet.ServletResponse) {
+            javax.servlet.ServletResponse cast = (javax.servlet.ServletResponse) delegate;
             return asJakarta(cast);
-        } else if (delegate instanceof javax.servlet.ServletContext cast) {
+        } else if (delegate instanceof javax.servlet.ServletContext) {
+            javax.servlet.ServletContext cast = (javax.servlet.ServletContext) delegate;
             return asJakarta(cast);
-        } else if (delegate instanceof javax.servlet.Servlet cast) {
+        } else if (delegate instanceof javax.servlet.Servlet) {
+            javax.servlet.Servlet cast = (javax.servlet.Servlet) delegate;
             return asJakarta(cast);
-        } else if (delegate instanceof javax.servlet.Filter cast) {
+        } else if (delegate instanceof javax.servlet.Filter) {
+            javax.servlet.Filter cast = (javax.servlet.Filter) delegate;
             return asJakarta(cast);
-        } else if (delegate instanceof javax.servlet.http.HttpSession cast) {
+        } else if (delegate instanceof javax.servlet.http.HttpSession) {
+            javax.servlet.http.HttpSession cast = (javax.servlet.http.HttpSession) delegate;
             return asJakarta(cast);
         }
         return delegate;

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaELContextAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaELContextAdapter.java
@@ -24,7 +24,8 @@ public class JakartaELContextAdapter extends ELContext implements Adapted<javax.
     private final javax.el.ELContext delegate;
 
     public static ELContext from(javax.el.ELContext delegate) {
-        if (delegate instanceof JavaXELContextAdapter castDelegate) {
+        if (delegate instanceof JavaXELContextAdapter) {
+            JavaXELContextAdapter castDelegate = (JavaXELContextAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaELContextAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaELContextEventAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaELContextEventAdapter.java
@@ -14,7 +14,8 @@ public class JakartaELContextEventAdapter extends ELContextEvent implements Adap
     private final javax.el.ELContextEvent delegate;
 
     public static ELContextEvent from(javax.el.ELContextEvent delegate) {
-        if (delegate instanceof JavaXELContextEventAdapter castDelegate) {
+        if (delegate instanceof JavaXELContextEventAdapter) {
+            JavaXELContextEventAdapter castDelegate = (JavaXELContextEventAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaELContextEventAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaELContextListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaELContextListenerAdapter.java
@@ -16,7 +16,8 @@ public class JakartaELContextListenerAdapter implements ELContextListener, Adapt
     private final javax.el.ELContextListener delegate;
 
     public static ELContextListener from(javax.el.ELContextListener delegate) {
-        if (delegate instanceof JavaXELContextListenerAdapter castDelegate) {
+        if (delegate instanceof JavaXELContextListenerAdapter) {
+            JavaXELContextListenerAdapter castDelegate = (JavaXELContextListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaELContextListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaEvaluationListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaEvaluationListenerAdapter.java
@@ -16,7 +16,8 @@ public class JakartaEvaluationListenerAdapter extends EvaluationListener impleme
     private final javax.el.EvaluationListener delegate;
 
     public static EvaluationListener from(javax.el.EvaluationListener delegate) {
-        if (delegate instanceof JavaXEvaluationListenerAdapter castDelegate) {
+        if (delegate instanceof JavaXEvaluationListenerAdapter) {
+            JavaXEvaluationListenerAdapter castDelegate = (JavaXEvaluationListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaEvaluationListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaExpressionFactoryAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaExpressionFactoryAdapter.java
@@ -21,7 +21,8 @@ public class JakartaExpressionFactoryAdapter extends ExpressionFactory implement
     private final javax.el.ExpressionFactory delegate;
 
     public static ExpressionFactory from(javax.el.ExpressionFactory delegate) {
-        if (delegate instanceof JavaXExpressionFactoryAdapter castDelegate) {
+        if (delegate instanceof JavaXExpressionFactoryAdapter) {
+            JavaXExpressionFactoryAdapter castDelegate = (JavaXExpressionFactoryAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaExpressionFactoryAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaFunctionMapperAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaFunctionMapperAdapter.java
@@ -15,7 +15,8 @@ public class JakartaFunctionMapperAdapter extends FunctionMapper implements Adap
     private final javax.el.FunctionMapper delegate;
 
     public static FunctionMapper from(javax.el.FunctionMapper delegate) {
-        if (delegate instanceof JavaXFunctionMapperAdapter castDelegate) {
+        if (delegate instanceof JavaXFunctionMapperAdapter) {
+            JavaXFunctionMapperAdapter castDelegate = (JavaXFunctionMapperAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaFunctionMapperAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaImportHandlerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaImportHandlerAdapter.java
@@ -15,7 +15,8 @@ public class JakartaImportHandlerAdapter extends ImportHandler implements Adapte
     private final javax.el.ImportHandler delegate;
 
     public static ImportHandler from(javax.el.ImportHandler delegate) {
-        if (delegate instanceof JavaXImportHandlerAdapter castDelegate) {
+        if (delegate instanceof JavaXImportHandlerAdapter) {
+            JavaXImportHandlerAdapter castDelegate = (JavaXImportHandlerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaImportHandlerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaMethodExpressionAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaMethodExpressionAdapter.java
@@ -17,7 +17,8 @@ public class JakartaMethodExpressionAdapter extends MethodExpression implements 
     private final javax.el.MethodExpression delegate;
 
     public static MethodExpression from(javax.el.MethodExpression delegate) {
-        if (delegate instanceof JavaXMethodExpressionAdapter castDelegate) {
+        if (delegate instanceof JavaXMethodExpressionAdapter) {
+            JavaXMethodExpressionAdapter castDelegate = (JavaXMethodExpressionAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaMethodExpressionAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaMethodInfoAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaMethodInfoAdapter.java
@@ -13,7 +13,8 @@ public class JakartaMethodInfoAdapter extends MethodInfo implements Adapted<java
     private final javax.el.MethodInfo delegate;
 
     public static MethodInfo from(javax.el.MethodInfo delegate) {
-        if (delegate instanceof JavaXMethodInfoAdapter castDelegate) {
+        if (delegate instanceof JavaXMethodInfoAdapter) {
+            JavaXMethodInfoAdapter castDelegate = (JavaXMethodInfoAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaMethodInfoAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaValueExpressionAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaValueExpressionAdapter.java
@@ -17,7 +17,8 @@ public class JakartaValueExpressionAdapter extends ValueExpression implements Ad
     private final javax.el.ValueExpression delegate;
 
     public static ValueExpression from(javax.el.ValueExpression delegate) {
-        if (delegate instanceof JavaXValueExpressionAdapter castDelegate) {
+        if (delegate instanceof JavaXValueExpressionAdapter) {
+            JavaXValueExpressionAdapter castDelegate = (JavaXValueExpressionAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaValueExpressionAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaValueReferenceAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaValueReferenceAdapter.java
@@ -13,7 +13,8 @@ public class JakartaValueReferenceAdapter extends ValueReference implements Adap
     private final javax.el.ValueReference delegate;
 
     public static ValueReference from(javax.el.ValueReference delegate) {
-        if (delegate instanceof JavaXValueReferenceAdapter castDelegate) {
+        if (delegate instanceof JavaXValueReferenceAdapter) {
+            JavaXValueReferenceAdapter castDelegate = (JavaXValueReferenceAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaValueReferenceAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaVariableMapperAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/el/JakartaVariableMapperAdapter.java
@@ -16,7 +16,8 @@ public class JakartaVariableMapperAdapter extends VariableMapper implements Adap
     private final javax.el.VariableMapper delegate;
 
     public static VariableMapper from(javax.el.VariableMapper delegate) {
-        if (delegate instanceof JavaXVariableMapperAdapter castDelegate) {
+        if (delegate instanceof JavaXVariableMapperAdapter) {
+            JavaXVariableMapperAdapter castDelegate = (JavaXVariableMapperAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaVariableMapperAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaAsyncContextAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaAsyncContextAdapter.java
@@ -22,7 +22,8 @@ public class JakartaAsyncContextAdapter implements AsyncContext, Adapted<javax.s
     private final javax.servlet.AsyncContext delegate;
 
     public static AsyncContext from(javax.servlet.AsyncContext delegate) {
-        if (delegate instanceof JavaXAsyncContextAdapter castDelegate) {
+        if (delegate instanceof JavaXAsyncContextAdapter) {
+            JavaXAsyncContextAdapter castDelegate = (JavaXAsyncContextAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaAsyncContextAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaAsyncEventAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaAsyncEventAdapter.java
@@ -18,7 +18,8 @@ public class JakartaAsyncEventAdapter extends AsyncEvent implements Adapted<java
     private final javax.servlet.AsyncEvent delegate;
 
     public static AsyncEvent from(javax.servlet.AsyncEvent delegate) {
-        if (delegate instanceof JavaXAsyncEventAdapter castDelegate) {
+        if (delegate instanceof JavaXAsyncEventAdapter) {
+            JavaXAsyncEventAdapter castDelegate = (JavaXAsyncEventAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaAsyncEventAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaAsyncListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaAsyncListenerAdapter.java
@@ -16,7 +16,8 @@ public class JakartaAsyncListenerAdapter implements AsyncListener, Adapted<javax
     private final javax.servlet.AsyncListener delegate;
 
     public static AsyncListener from(javax.servlet.AsyncListener delegate) {
-        if (delegate instanceof JavaXAsyncListenerAdapter castDelegate) {
+        if (delegate instanceof JavaXAsyncListenerAdapter) {
+            JavaXAsyncListenerAdapter castDelegate = (JavaXAsyncListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaAsyncListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaDynamicFilterRegistrationAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaDynamicFilterRegistrationAdapter.java
@@ -13,7 +13,8 @@ public class JakartaDynamicFilterRegistrationAdapter extends JakartaFilterRegist
     private final javax.servlet.FilterRegistration.Dynamic delegate;
 
     public static FilterRegistration.Dynamic from(javax.servlet.FilterRegistration.Dynamic delegate) {
-        if (delegate instanceof JavaXDynamicFilterRegistrationAdapter castDelegate) {
+        if (delegate instanceof JavaXDynamicFilterRegistrationAdapter) {
+            JavaXDynamicFilterRegistrationAdapter castDelegate = (JavaXDynamicFilterRegistrationAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaDynamicFilterRegistrationAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaDynamicServletRegistrationAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaDynamicServletRegistrationAdapter.java
@@ -18,7 +18,8 @@ public class JakartaDynamicServletRegistrationAdapter extends JakartaServletRegi
     private final javax.servlet.ServletRegistration.Dynamic delegate;
 
     public static ServletRegistration.Dynamic from(javax.servlet.ServletRegistration.Dynamic delegate) {
-        if (delegate instanceof JavaXDynamicServletRegistrationAdapter castDelegate) {
+        if (delegate instanceof JavaXDynamicServletRegistrationAdapter) {
+            JavaXDynamicServletRegistrationAdapter castDelegate = (JavaXDynamicServletRegistrationAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaDynamicServletRegistrationAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaFilterAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaFilterAdapter.java
@@ -24,10 +24,12 @@ public class JakartaFilterAdapter implements Filter, Adapted<javax.servlet.Filte
     private final javax.servlet.Filter delegate;
 
     public static Filter from(javax.servlet.Filter delegate) {
-        if (delegate instanceof GenericFilter castDelegate) {
+        if (delegate instanceof GenericFilter) {
+            GenericFilter castDelegate = (GenericFilter) delegate;
             return JakartaGenericFilterAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXFilterAdapter castDelegate) {
+        if (delegate instanceof JavaXFilterAdapter) {
+            JavaXFilterAdapter castDelegate = (JavaXFilterAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaFilterAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaFilterChainAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaFilterChainAdapter.java
@@ -19,7 +19,8 @@ public class JakartaFilterChainAdapter implements FilterChain, Adapted<javax.ser
     private final javax.servlet.FilterChain delegate;
 
     public static FilterChain from(javax.servlet.FilterChain delegate) {
-        if (delegate instanceof JavaXFilterChainAdapter castDelegate) {
+        if (delegate instanceof JavaXFilterChainAdapter) {
+            JavaXFilterChainAdapter castDelegate = (JavaXFilterChainAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaFilterChainAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaFilterConfigAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaFilterConfigAdapter.java
@@ -17,7 +17,8 @@ public class JakartaFilterConfigAdapter implements FilterConfig, Adapted<javax.s
     private final javax.servlet.FilterConfig delegate;
 
     public static FilterConfig from(javax.servlet.FilterConfig delegate) {
-        if (delegate instanceof JavaXFilterConfigAdapter castDelegate) {
+        if (delegate instanceof JavaXFilterConfigAdapter) {
+            JavaXFilterConfigAdapter castDelegate = (JavaXFilterConfigAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaFilterConfigAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaFilterRegistrationAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaFilterRegistrationAdapter.java
@@ -16,10 +16,12 @@ public class JakartaFilterRegistrationAdapter extends JakartaRegistrationAdapter
     private final javax.servlet.FilterRegistration delegate;
 
     public static FilterRegistration from(javax.servlet.FilterRegistration delegate) {
-        if (delegate instanceof javax.servlet.FilterRegistration.Dynamic castDelegate) {
+        if (delegate instanceof javax.servlet.FilterRegistration.Dynamic) {
+            javax.servlet.FilterRegistration.Dynamic castDelegate = (javax.servlet.FilterRegistration.Dynamic) delegate;
             return JakartaDynamicFilterRegistrationAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXFilterRegistrationAdapter castDelegate) {
+        if (delegate instanceof JavaXFilterRegistrationAdapter) {
+            JavaXFilterRegistrationAdapter castDelegate = (JavaXFilterRegistrationAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaFilterRegistrationAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaGenericFilterAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaGenericFilterAdapter.java
@@ -25,10 +25,12 @@ public class JakartaGenericFilterAdapter extends GenericFilter implements Adapte
     private final javax.servlet.GenericFilter delegate;
 
     public static GenericFilter from(javax.servlet.GenericFilter delegate) {
-        if (delegate instanceof javax.servlet.http.HttpFilter castDelegate) {
+        if (delegate instanceof javax.servlet.http.HttpFilter) {
+            javax.servlet.http.HttpFilter castDelegate = (javax.servlet.http.HttpFilter) delegate;
             return JakartaHttpFilterAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXGenericFilterAdapter castDelegate) {
+        if (delegate instanceof JavaXGenericFilterAdapter) {
+            JavaXGenericFilterAdapter castDelegate = (JavaXGenericFilterAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaGenericFilterAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaGenericServletAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaGenericServletAdapter.java
@@ -24,10 +24,12 @@ public class JakartaGenericServletAdapter extends GenericServlet implements Adap
     private final javax.servlet.GenericServlet delegate;
 
     public static GenericServlet from(javax.servlet.GenericServlet delegate) {
-        if (delegate instanceof javax.servlet.http.HttpServlet castDelegate) {
+        if (delegate instanceof javax.servlet.http.HttpServlet) {
+            javax.servlet.http.HttpServlet castDelegate = (javax.servlet.http.HttpServlet) delegate;
             return JakartaHttpServletAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXGenericServletAdapter castDelegate) {
+        if (delegate instanceof JavaXGenericServletAdapter) {
+            JavaXGenericServletAdapter castDelegate = (JavaXGenericServletAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaGenericServletAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaHttpMethodConstraintElementAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaHttpMethodConstraintElementAdapter.java
@@ -15,7 +15,8 @@ public class JakartaHttpMethodConstraintElementAdapter extends HttpMethodConstra
     private final javax.servlet.HttpMethodConstraintElement delegate;
 
     public static HttpMethodConstraintElement from(javax.servlet.HttpMethodConstraintElement delegate) {
-        if (delegate instanceof JavaXHttpMethodConstraintElementAdapter castDelegate) {
+        if (delegate instanceof JavaXHttpMethodConstraintElementAdapter) {
+            JavaXHttpMethodConstraintElementAdapter castDelegate = (JavaXHttpMethodConstraintElementAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaHttpMethodConstraintElementAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaMultipartConfigElementAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaMultipartConfigElementAdapter.java
@@ -14,7 +14,8 @@ public class JakartaMultipartConfigElementAdapter extends MultipartConfigElement
     private final javax.servlet.MultipartConfigElement delegate;
 
     public static MultipartConfigElement from(javax.servlet.MultipartConfigElement delegate) {
-        if (delegate instanceof JavaXMultipartConfigElementAdapter castDelegate) {
+        if (delegate instanceof JavaXMultipartConfigElementAdapter) {
+            JavaXMultipartConfigElementAdapter castDelegate = (JavaXMultipartConfigElementAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaMultipartConfigElementAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaReadListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaReadListenerAdapter.java
@@ -14,7 +14,8 @@ public class JakartaReadListenerAdapter implements ReadListener, Adapted<javax.s
     private final javax.servlet.ReadListener delegate;
 
     public static ReadListener from(javax.servlet.ReadListener delegate) {
-        if (delegate instanceof JavaXReadListenerAdapter castDelegate) {
+        if (delegate instanceof JavaXReadListenerAdapter) {
+            JavaXReadListenerAdapter castDelegate = (JavaXReadListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaReadListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaRegistrationAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaRegistrationAdapter.java
@@ -16,13 +16,16 @@ public class JakartaRegistrationAdapter implements Registration, Adapted<javax.s
     private final javax.servlet.Registration delegate;
 
     public static Registration from(javax.servlet.Registration delegate) {
-        if (delegate instanceof javax.servlet.ServletRegistration castDelegate) {
+        if (delegate instanceof javax.servlet.ServletRegistration) {
+            javax.servlet.ServletRegistration castDelegate = (javax.servlet.ServletRegistration) delegate;
             return JakartaServletRegistrationAdapter.from(castDelegate);
         }
-        if (delegate instanceof javax.servlet.FilterRegistration castDelegate) {
+        if (delegate instanceof javax.servlet.FilterRegistration) {
+            javax.servlet.FilterRegistration castDelegate = (javax.servlet.FilterRegistration) delegate;
             return JakartaFilterRegistrationAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXRegistrationAdapter castDelegate) {
+        if (delegate instanceof JavaXRegistrationAdapter) {
+            JavaXRegistrationAdapter castDelegate = (JavaXRegistrationAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaRegistrationAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaRequestDispatcherAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaRequestDispatcherAdapter.java
@@ -18,7 +18,8 @@ public class JakartaRequestDispatcherAdapter implements RequestDispatcher, Adapt
     private final javax.servlet.RequestDispatcher delegate;
 
     public static RequestDispatcher from(javax.servlet.RequestDispatcher delegate) {
-        if (delegate instanceof JavaXRequestDispatcherAdapter castDelegate) {
+        if (delegate instanceof JavaXRequestDispatcherAdapter) {
+            JavaXRequestDispatcherAdapter castDelegate = (JavaXRequestDispatcherAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaRequestDispatcherAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletAdapter.java
@@ -21,10 +21,12 @@ public class JakartaServletAdapter implements Servlet, Adapted<javax.servlet.Ser
     private final javax.servlet.Servlet delegate;
 
     public static Servlet from(javax.servlet.Servlet delegate) {
-        if (delegate instanceof javax.servlet.GenericServlet castDelegate) {
+        if (delegate instanceof javax.servlet.GenericServlet) {
+            javax.servlet.GenericServlet castDelegate = (javax.servlet.GenericServlet) delegate;
             return JakartaGenericServletAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXServletAdapter castDelegate) {
+        if (delegate instanceof JavaXServletAdapter) {
+            JavaXServletAdapter castDelegate = (JavaXServletAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletConfigAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletConfigAdapter.java
@@ -17,7 +17,8 @@ public class JakartaServletConfigAdapter implements ServletConfig, Adapted<javax
     private final javax.servlet.ServletConfig delegate;
 
     public static ServletConfig from(javax.servlet.ServletConfig delegate) {
-        if (delegate instanceof JavaXServletConfigAdapter castDelegate) {
+        if (delegate instanceof JavaXServletConfigAdapter) {
+            JavaXServletConfigAdapter castDelegate = (JavaXServletConfigAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletConfigAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletContextAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletContextAdapter.java
@@ -40,7 +40,8 @@ public class JakartaServletContextAdapter implements ServletContext, Adapted<jav
     private final javax.servlet.ServletContext delegate;
 
     public static ServletContext from(javax.servlet.ServletContext delegate) {
-        if (delegate instanceof JavaXServletContextAdapter castDelegate) {
+        if (delegate instanceof JavaXServletContextAdapter) {
+            JavaXServletContextAdapter castDelegate = (JavaXServletContextAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletContextAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletContextEventAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletContextEventAdapter.java
@@ -15,7 +15,8 @@ public class JakartaServletContextEventAdapter extends ServletContextEvent imple
     private final javax.servlet.ServletContextEvent delegate;
 
     public static ServletContextEvent from(javax.servlet.ServletContextEvent delegate) {
-        if (delegate instanceof JavaXServletContextEventAdapter castDelegate) {
+        if (delegate instanceof JavaXServletContextEventAdapter) {
+            JavaXServletContextEventAdapter castDelegate = (JavaXServletContextEventAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletContextEventAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletContextListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletContextListenerAdapter.java
@@ -16,7 +16,8 @@ public class JakartaServletContextListenerAdapter implements ServletContextListe
     private final javax.servlet.ServletContextListener delegate;
 
     public static ServletContextListener from(javax.servlet.ServletContextListener delegate) {
-        if (delegate instanceof JavaXServletContextListenerAdapter castDelegate) {
+        if (delegate instanceof JavaXServletContextListenerAdapter) {
+            JavaXServletContextListenerAdapter castDelegate = (JavaXServletContextListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletContextListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletInputStreamAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletInputStreamAdapter.java
@@ -9,6 +9,8 @@ import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import static io.atlassian.util.adapter.util.WrapperUtil.applyIfNonNull;
 import static java.util.Objects.requireNonNull;
@@ -69,9 +71,21 @@ public class JakartaServletInputStreamAdapter extends ServletInputStream impleme
         return delegate.skip(n);
     }
 
-    @Override
     public void skipNBytes(long n) throws IOException {
-        delegate.skipNBytes(n);
+        try {
+            Method skipNBytes = delegate.getClass().getMethod("skipNBytes", long.class);
+            skipNBytes.invoke(delegate, n);
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException("Could not find or invoke skipNBytes on delegate stream.", e);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            } else if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            } else {
+                throw new RuntimeException(e.getCause());
+            }
+        }
     }
 
     @Override

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletInputStreamAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletInputStreamAdapter.java
@@ -18,7 +18,8 @@ public class JakartaServletInputStreamAdapter extends ServletInputStream impleme
     private final javax.servlet.ServletInputStream delegate;
 
     public static ServletInputStream from(javax.servlet.ServletInputStream delegate) {
-        if (delegate instanceof JavaXServletInputStreamAdapter castDelegate) {
+        if (delegate instanceof JavaXServletInputStreamAdapter) {
+            JavaXServletInputStreamAdapter castDelegate = (JavaXServletInputStreamAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletInputStreamAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletOutputStreamAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletOutputStreamAdapter.java
@@ -17,7 +17,8 @@ public class JakartaServletOutputStreamAdapter extends ServletOutputStream imple
     private final javax.servlet.ServletOutputStream delegate;
 
     public static ServletOutputStream from(javax.servlet.ServletOutputStream delegate) {
-        if (delegate instanceof JavaXServletOutputStreamAdapter castDelegate) {
+        if (delegate instanceof JavaXServletOutputStreamAdapter) {
+            JavaXServletOutputStreamAdapter castDelegate = (JavaXServletOutputStreamAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletOutputStreamAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletRegistrationAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletRegistrationAdapter.java
@@ -15,10 +15,12 @@ public class JakartaServletRegistrationAdapter extends JakartaRegistrationAdapte
     private final javax.servlet.ServletRegistration delegate;
 
     public static ServletRegistration from(javax.servlet.ServletRegistration delegate) {
-        if (delegate instanceof javax.servlet.ServletRegistration.Dynamic castDelegate) {
+        if (delegate instanceof javax.servlet.ServletRegistration.Dynamic) {
+            javax.servlet.ServletRegistration.Dynamic castDelegate = (javax.servlet.ServletRegistration.Dynamic) delegate;
             return JakartaDynamicServletRegistrationAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXServletRegistrationAdapter castDelegate) {
+        if (delegate instanceof JavaXServletRegistrationAdapter) {
+            JavaXServletRegistrationAdapter castDelegate = (JavaXServletRegistrationAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletRegistrationAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletRequestAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletRequestAdapter.java
@@ -32,13 +32,16 @@ public class JakartaServletRequestAdapter implements ServletRequest, Adapted<jav
     private final javax.servlet.ServletRequest delegate;
 
     public static ServletRequest from(javax.servlet.ServletRequest delegate) {
-        if (delegate instanceof javax.servlet.http.HttpServletRequest castDelegate) {
+        if (delegate instanceof javax.servlet.http.HttpServletRequest) {
+            javax.servlet.http.HttpServletRequest castDelegate = (javax.servlet.http.HttpServletRequest) delegate;
             return JakartaHttpServletRequestAdapter.from(castDelegate);
         }
-        if (delegate instanceof javax.servlet.ServletRequestWrapper castDelegate) {
+        if (delegate instanceof javax.servlet.ServletRequestWrapper) {
+            javax.servlet.ServletRequestWrapper castDelegate = (javax.servlet.ServletRequestWrapper) delegate;
             return JakartaServletRequestWrapperAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXServletRequestAdapter castDelegate) {
+        if (delegate instanceof JavaXServletRequestAdapter) {
+            JavaXServletRequestAdapter castDelegate = (JavaXServletRequestAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletRequestAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletRequestWrapperAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletRequestWrapperAdapter.java
@@ -14,10 +14,12 @@ import static io.atlassian.util.adapter.util.WrapperUtil.applyIfNonNull;
 public class JakartaServletRequestWrapperAdapter extends ServletRequestWrapper implements Adapted<javax.servlet.ServletRequestWrapper> {
 
     public static ServletRequestWrapper from(javax.servlet.ServletRequestWrapper delegate) {
-        if (delegate instanceof javax.servlet.http.HttpServletRequestWrapper castDelegate) {
+        if (delegate instanceof javax.servlet.http.HttpServletRequestWrapper) {
+            javax.servlet.http.HttpServletRequestWrapper castDelegate = (javax.servlet.http.HttpServletRequestWrapper) delegate;
             return JakartaHttpServletRequestWrapperAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXServletRequestWrapperAdapter castDelegate) {
+        if (delegate instanceof JavaXServletRequestWrapperAdapter) {
+            JavaXServletRequestWrapperAdapter castDelegate = (JavaXServletRequestWrapperAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletRequestWrapperAdapter::new);
@@ -34,7 +36,8 @@ public class JakartaServletRequestWrapperAdapter extends ServletRequestWrapper i
 
     @Override
     public boolean isWrapperFor(Class<?> wrappedType) {
-        if (getRequest() instanceof ServletRequestWrapper wrapper) {
+        if (getRequest() instanceof ServletRequestWrapper) {
+            ServletRequestWrapper wrapper = (ServletRequestWrapper) getRequest();
             return wrapper.isWrapperFor(wrappedType);
         }
         return false;
@@ -42,7 +45,8 @@ public class JakartaServletRequestWrapperAdapter extends ServletRequestWrapper i
 
     @Override
     public boolean isWrapperFor(ServletRequest wrapped) {
-        if (getRequest() instanceof ServletRequestWrapper wrapper) {
+        if (getRequest() instanceof ServletRequestWrapper) {
+            ServletRequestWrapper wrapper = (ServletRequestWrapper) getRequest();
             return wrapper.isWrapperFor(wrapped);
         }
         return false;

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletResponseAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletResponseAdapter.java
@@ -19,10 +19,12 @@ public class JakartaServletResponseAdapter implements ServletResponse, Adapted<j
     private final javax.servlet.ServletResponse delegate;
 
     public static ServletResponse from(javax.servlet.ServletResponse delegate) {
-        if (delegate instanceof javax.servlet.http.HttpServletResponse castDelegate) {
+        if (delegate instanceof javax.servlet.http.HttpServletResponse) {
+            javax.servlet.http.HttpServletResponse castDelegate = (javax.servlet.http.HttpServletResponse) delegate;
             return JakartaHttpServletResponseAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXServletResponseAdapter castDelegate) {
+        if (delegate instanceof JavaXServletResponseAdapter) {
+            JavaXServletResponseAdapter castDelegate = (JavaXServletResponseAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletResponseAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletSecurityElementAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletSecurityElementAdapter.java
@@ -18,7 +18,8 @@ public class JakartaServletSecurityElementAdapter extends ServletSecurityElement
     private final javax.servlet.ServletSecurityElement delegate;
 
     public static ServletSecurityElement from(javax.servlet.ServletSecurityElement delegate) {
-        if (delegate instanceof JavaXServletSecurityElementAdapter castDelegate) {
+        if (delegate instanceof JavaXServletSecurityElementAdapter) {
+            JavaXServletSecurityElementAdapter castDelegate = (JavaXServletSecurityElementAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaServletSecurityElementAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaSessionCookieConfigAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaSessionCookieConfigAdapter.java
@@ -15,7 +15,8 @@ public class JakartaSessionCookieConfigAdapter implements SessionCookieConfig, A
     private final javax.servlet.SessionCookieConfig delegate;
 
     public static SessionCookieConfig from(javax.servlet.SessionCookieConfig delegate) {
-        if (delegate instanceof JavaXSessionCookieConfigAdapter castDelegate) {
+        if (delegate instanceof JavaXSessionCookieConfigAdapter) {
+            JavaXSessionCookieConfigAdapter castDelegate = (JavaXSessionCookieConfigAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaSessionCookieConfigAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaWriteListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/JakartaWriteListenerAdapter.java
@@ -14,7 +14,8 @@ public class JakartaWriteListenerAdapter implements WriteListener, Adapted<javax
     private final javax.servlet.WriteListener delegate;
 
     public static WriteListener from(javax.servlet.WriteListener delegate) {
-        if (delegate instanceof JavaXWriteListenerAdapter castDelegate) {
+        if (delegate instanceof JavaXWriteListenerAdapter) {
+            JavaXWriteListenerAdapter castDelegate = (JavaXWriteListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaWriteListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/descriptor/JakartaJspConfigDescriptorAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/descriptor/JakartaJspConfigDescriptorAdapter.java
@@ -18,7 +18,8 @@ public class JakartaJspConfigDescriptorAdapter implements JspConfigDescriptor, A
     private final javax.servlet.descriptor.JspConfigDescriptor delegate;
 
     public static JspConfigDescriptor from(javax.servlet.descriptor.JspConfigDescriptor delegate) {
-        if (delegate instanceof JavaXJspConfigDescriptorAdapter castDelegate) {
+        if (delegate instanceof JavaXJspConfigDescriptorAdapter) {
+            JavaXJspConfigDescriptorAdapter castDelegate = (JavaXJspConfigDescriptorAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaJspConfigDescriptorAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/descriptor/JakartaJspPropertyGroupDescriptorAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/descriptor/JakartaJspPropertyGroupDescriptorAdapter.java
@@ -15,7 +15,8 @@ public class JakartaJspPropertyGroupDescriptorAdapter implements JspPropertyGrou
     private final javax.servlet.descriptor.JspPropertyGroupDescriptor delegate;
 
     public static JspPropertyGroupDescriptor from(javax.servlet.descriptor.JspPropertyGroupDescriptor delegate) {
-        if (delegate instanceof JavaXJspPropertyGroupDescriptorAdapter castDelegate) {
+        if (delegate instanceof JavaXJspPropertyGroupDescriptorAdapter) {
+            JavaXJspPropertyGroupDescriptorAdapter castDelegate = (JavaXJspPropertyGroupDescriptorAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaJspPropertyGroupDescriptorAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/descriptor/JakartaTaglibDescriptorAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/descriptor/JakartaTaglibDescriptorAdapter.java
@@ -14,7 +14,8 @@ public class JakartaTaglibDescriptorAdapter implements TaglibDescriptor, Adapted
     private final javax.servlet.descriptor.TaglibDescriptor delegate;
 
     public static TaglibDescriptor from(javax.servlet.descriptor.TaglibDescriptor delegate) {
-        if (delegate instanceof JavaXTaglibDescriptorAdapter castDelegate) {
+        if (delegate instanceof JavaXTaglibDescriptorAdapter) {
+            JavaXTaglibDescriptorAdapter castDelegate = (JavaXTaglibDescriptorAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaTaglibDescriptorAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaCookieAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaCookieAdapter.java
@@ -18,7 +18,8 @@ public class JakartaCookieAdapter extends Cookie implements Adapted<javax.servle
     private javax.servlet.http.Cookie delegate;
 
     public static Cookie from(javax.servlet.http.Cookie delegate) {
-        if (delegate instanceof JavaXCookieAdapter castDelegate) {
+        if (delegate instanceof JavaXCookieAdapter) {
+            JavaXCookieAdapter castDelegate = (JavaXCookieAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaCookieAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpFilterAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpFilterAdapter.java
@@ -24,7 +24,8 @@ public class JakartaHttpFilterAdapter extends HttpFilter implements Adapted<java
     private final javax.servlet.http.HttpFilter delegate;
 
     public static HttpFilter from(javax.servlet.http.HttpFilter delegate) {
-        if (delegate instanceof JavaXHttpFilterAdapter castDelegate) {
+        if (delegate instanceof JavaXHttpFilterAdapter) {
+            JavaXHttpFilterAdapter castDelegate = (JavaXHttpFilterAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaHttpFilterAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletAdapter.java
@@ -23,7 +23,8 @@ public class JakartaHttpServletAdapter extends HttpServlet implements Adapted<ja
     private final javax.servlet.http.HttpServlet delegate;
 
     public static HttpServlet from(javax.servlet.http.HttpServlet delegate) {
-        if (delegate instanceof JavaXHttpServletAdapter castDelegate) {
+        if (delegate instanceof JavaXHttpServletAdapter) {
+            JavaXHttpServletAdapter castDelegate = (JavaXHttpServletAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaHttpServletAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletMappingAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletMappingAdapter.java
@@ -15,7 +15,8 @@ public class JakartaHttpServletMappingAdapter implements HttpServletMapping, Ada
     private final javax.servlet.http.HttpServletMapping delegate;
 
     public static HttpServletMapping from(javax.servlet.http.HttpServletMapping delegate) {
-        if (delegate instanceof JavaXHttpServletMappingAdapter castDelegate) {
+        if (delegate instanceof JavaXHttpServletMappingAdapter) {
+            JavaXHttpServletMappingAdapter castDelegate = (JavaXHttpServletMappingAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaHttpServletMappingAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletRequestAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletRequestAdapter.java
@@ -29,10 +29,12 @@ public class JakartaHttpServletRequestAdapter extends JakartaServletRequestAdapt
     private final javax.servlet.http.HttpServletRequest delegate;
 
     public static HttpServletRequest from(javax.servlet.http.HttpServletRequest delegate) {
-        if (delegate instanceof javax.servlet.http.HttpServletRequestWrapper castDelegate) {
+        if (delegate instanceof javax.servlet.http.HttpServletRequestWrapper) {
+            javax.servlet.http.HttpServletRequestWrapper castDelegate = (javax.servlet.http.HttpServletRequestWrapper) delegate;
             return JakartaHttpServletRequestWrapperAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXHttpServletRequestAdapter castDelegate) {
+        if (delegate instanceof JavaXHttpServletRequestAdapter) {
+            JavaXHttpServletRequestAdapter castDelegate = (JavaXHttpServletRequestAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaHttpServletRequestAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletRequestWrapperAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletRequestWrapperAdapter.java
@@ -15,7 +15,8 @@ import static io.atlassian.util.adapter.util.WrapperUtil.applyIfNonNull;
 public class JakartaHttpServletRequestWrapperAdapter extends HttpServletRequestWrapper implements Adapted<javax.servlet.http.HttpServletRequestWrapper> {
 
     public static HttpServletRequestWrapper from(javax.servlet.http.HttpServletRequestWrapper delegate) {
-        if (delegate instanceof JavaXHttpServletRequestWrapperAdapter castDelegate) {
+        if (delegate instanceof JavaXHttpServletRequestWrapperAdapter) {
+            JavaXHttpServletRequestWrapperAdapter castDelegate = (JavaXHttpServletRequestWrapperAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaHttpServletRequestWrapperAdapter::new);
@@ -32,7 +33,8 @@ public class JakartaHttpServletRequestWrapperAdapter extends HttpServletRequestW
 
     @Override
     public boolean isWrapperFor(Class<?> wrappedType) {
-        if (getRequest() instanceof ServletRequestWrapper wrapper) {
+        if (getRequest() instanceof ServletRequestWrapper) {
+            ServletRequestWrapper wrapper = (ServletRequestWrapper) getRequest();
             return wrapper.isWrapperFor(wrappedType);
         }
         return false;
@@ -40,7 +42,8 @@ public class JakartaHttpServletRequestWrapperAdapter extends HttpServletRequestW
 
     @Override
     public boolean isWrapperFor(ServletRequest wrapped) {
-        if (getRequest() instanceof ServletRequestWrapper wrapper) {
+        if (getRequest() instanceof ServletRequestWrapper) {
+            ServletRequestWrapper wrapper = (ServletRequestWrapper) getRequest();
             return wrapper.isWrapperFor(wrapped);
         }
         return false;

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletResponseAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletResponseAdapter.java
@@ -19,7 +19,8 @@ public class JakartaHttpServletResponseAdapter extends JakartaServletResponseAda
     private final javax.servlet.http.HttpServletResponse delegate;
 
     public static HttpServletResponse from(javax.servlet.http.HttpServletResponse delegate) {
-        if (delegate instanceof JavaXHttpServletResponseAdapter castDelegate) {
+        if (delegate instanceof JavaXHttpServletResponseAdapter) {
+            JavaXHttpServletResponseAdapter castDelegate = (JavaXHttpServletResponseAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaHttpServletResponseAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpSessionAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpSessionAdapter.java
@@ -18,7 +18,8 @@ public class JakartaHttpSessionAdapter implements HttpSession, Adapted<javax.ser
     private final javax.servlet.http.HttpSession delegate;
 
     public static HttpSession from(javax.servlet.http.HttpSession delegate) {
-        if (delegate instanceof JavaXHttpSessionAdapter castDelegate) {
+        if (delegate instanceof JavaXHttpSessionAdapter) {
+            JavaXHttpSessionAdapter castDelegate = (JavaXHttpSessionAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaHttpSessionAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpUpgradeHandlerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpUpgradeHandlerAdapter.java
@@ -16,7 +16,8 @@ public class JakartaHttpUpgradeHandlerAdapter implements HttpUpgradeHandler, Ada
     private final javax.servlet.http.HttpUpgradeHandler delegate;
 
     public static HttpUpgradeHandler from(javax.servlet.http.HttpUpgradeHandler delegate) {
-        if (delegate instanceof JavaXHttpUpgradeHandlerAdapter castDelegate) {
+        if (delegate instanceof JavaXHttpUpgradeHandlerAdapter) {
+            JavaXHttpUpgradeHandlerAdapter castDelegate = (JavaXHttpUpgradeHandlerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaHttpUpgradeHandlerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaPartAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaPartAdapter.java
@@ -17,7 +17,8 @@ public class JakartaPartAdapter implements Part, Adapted<javax.servlet.http.Part
     private final javax.servlet.http.Part delegate;
 
     public static Part from(javax.servlet.http.Part delegate) {
-        if (delegate instanceof JavaXPartAdapter castDelegate) {
+        if (delegate instanceof JavaXPartAdapter) {
+            JavaXPartAdapter castDelegate = (JavaXPartAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaPartAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaPushBuilderAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaPushBuilderAdapter.java
@@ -15,7 +15,8 @@ public class JakartaPushBuilderAdapter implements PushBuilder, Adapted<javax.ser
     private final javax.servlet.http.PushBuilder delegate;
 
     public static PushBuilder from(javax.servlet.http.PushBuilder delegate) {
-        if (delegate instanceof JavaXPushBuilderAdapter castDelegate) {
+        if (delegate instanceof JavaXPushBuilderAdapter) {
+            JavaXPushBuilderAdapter castDelegate = (JavaXPushBuilderAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaPushBuilderAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaWebConnectionAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaWebConnectionAdapter.java
@@ -18,7 +18,8 @@ public class JakartaWebConnectionAdapter implements WebConnection, Adapted<javax
     private final javax.servlet.http.WebConnection delegate;
 
     public static WebConnection from(javax.servlet.http.WebConnection delegate) {
-        if (delegate instanceof JavaXWebConnectionAdapter castDelegate) {
+        if (delegate instanceof JavaXWebConnectionAdapter) {
+            JavaXWebConnectionAdapter castDelegate = (JavaXWebConnectionAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaWebConnectionAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/JakartaJspApplicationContextAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/JakartaJspApplicationContextAdapter.java
@@ -19,7 +19,8 @@ public class JakartaJspApplicationContextAdapter implements JspApplicationContex
     private final javax.servlet.jsp.JspApplicationContext delegate;
 
     public static JspApplicationContext from(javax.servlet.jsp.JspApplicationContext delegate) {
-        if (delegate instanceof JavaXJspApplicationContextAdapter castDelegate) {
+        if (delegate instanceof JavaXJspApplicationContextAdapter) {
+            JavaXJspApplicationContextAdapter castDelegate = (JavaXJspApplicationContextAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaJspApplicationContextAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/JakartaJspEngineInfoAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/JakartaJspEngineInfoAdapter.java
@@ -14,7 +14,8 @@ public class JakartaJspEngineInfoAdapter extends JspEngineInfo implements Adapte
     private final javax.servlet.jsp.JspEngineInfo delegate;
 
     public static JspEngineInfo from(javax.servlet.jsp.JspEngineInfo delegate) {
-        if (delegate instanceof JavaXJspEngineInfoAdapter castDelegate) {
+        if (delegate instanceof JavaXJspEngineInfoAdapter) {
+            JavaXJspEngineInfoAdapter castDelegate = (JavaXJspEngineInfoAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaJspEngineInfoAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/JakartaJspFactoryAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/JakartaJspFactoryAdapter.java
@@ -22,7 +22,8 @@ public class JakartaJspFactoryAdapter extends JspFactory implements Adapted<java
     private final javax.servlet.jsp.JspFactory delegate;
 
     public static JspFactory from(javax.servlet.jsp.JspFactory delegate) {
-        if (delegate instanceof JavaXJspFactoryAdapter castDelegate) {
+        if (delegate instanceof JavaXJspFactoryAdapter) {
+            JavaXJspFactoryAdapter castDelegate = (JavaXJspFactoryAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaJspFactoryAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/JakartaJspWriterAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/JakartaJspWriterAdapter.java
@@ -16,10 +16,12 @@ public class JakartaJspWriterAdapter extends JspWriter implements Adapted<javax.
     private final javax.servlet.jsp.JspWriter delegate;
 
     public static JspWriter from(javax.servlet.jsp.JspWriter delegate) {
-        if (delegate instanceof javax.servlet.jsp.tagext.BodyContent castDelegate) {
+        if (delegate instanceof javax.servlet.jsp.tagext.BodyContent) {
+            javax.servlet.jsp.tagext.BodyContent castDelegate = (javax.servlet.jsp.tagext.BodyContent) delegate;
             return JakartaBodyContentAdapter.from(castDelegate);
         }
-        if (delegate instanceof JavaXJspWriterAdapter castDelegate) {
+        if (delegate instanceof JavaXJspWriterAdapter) {
+            JavaXJspWriterAdapter castDelegate = (JavaXJspWriterAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaJspWriterAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/JakartaPageContextAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/JakartaPageContextAdapter.java
@@ -34,7 +34,8 @@ public class JakartaPageContextAdapter extends jakarta.servlet.jsp.PageContext i
     private final javax.servlet.jsp.PageContext delegate;
 
     public static jakarta.servlet.jsp.PageContext from(javax.servlet.jsp.PageContext delegate) {
-        if (delegate instanceof JavaXPageContextAdapter castDelegate) {
+        if (delegate instanceof JavaXPageContextAdapter) {
+            JavaXPageContextAdapter castDelegate = (JavaXPageContextAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaPageContextAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/el/JakartaExpressionAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/el/JakartaExpressionAdapter.java
@@ -17,7 +17,8 @@ public class JakartaExpressionAdapter extends Expression implements Adapted<java
     private final javax.servlet.jsp.el.Expression delegate;
 
     public static Expression from(javax.servlet.jsp.el.Expression delegate) {
-        if (delegate instanceof JavaXExpressionAdapter castDelegate) {
+        if (delegate instanceof JavaXExpressionAdapter) {
+            JavaXExpressionAdapter castDelegate = (JavaXExpressionAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaExpressionAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/el/JakartaExpressionEvaluatorAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/el/JakartaExpressionEvaluatorAdapter.java
@@ -20,7 +20,8 @@ public class JakartaExpressionEvaluatorAdapter extends ExpressionEvaluator imple
     private final javax.servlet.jsp.el.ExpressionEvaluator delegate;
 
     public static ExpressionEvaluator from(javax.servlet.jsp.el.ExpressionEvaluator delegate) {
-        if (delegate instanceof JavaXExpressionEvaluatorAdapter castDelegate) {
+        if (delegate instanceof JavaXExpressionEvaluatorAdapter) {
+            JavaXExpressionEvaluatorAdapter castDelegate = (JavaXExpressionEvaluatorAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaExpressionEvaluatorAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/el/JakartaFunctionMapperAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/el/JakartaFunctionMapperAdapter.java
@@ -15,7 +15,8 @@ public class JakartaFunctionMapperAdapter implements FunctionMapper, Adapted<jav
     private final javax.servlet.jsp.el.FunctionMapper delegate;
 
     public static FunctionMapper from(javax.servlet.jsp.el.FunctionMapper delegate) {
-        if (delegate instanceof JavaXFunctionMapperAdapter castDelegate) {
+        if (delegate instanceof JavaXFunctionMapperAdapter) {
+            JavaXFunctionMapperAdapter castDelegate = (JavaXFunctionMapperAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaFunctionMapperAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/el/JakartaVariableResolverAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/el/JakartaVariableResolverAdapter.java
@@ -15,7 +15,8 @@ public class JakartaVariableResolverAdapter implements VariableResolver, Adapted
     private final javax.servlet.jsp.el.VariableResolver delegate;
 
     public static VariableResolver from(javax.servlet.jsp.el.VariableResolver delegate) {
-        if (delegate instanceof JavaXVariableResolverAdapter castDelegate) {
+        if (delegate instanceof JavaXVariableResolverAdapter) {
+            JavaXVariableResolverAdapter castDelegate = (JavaXVariableResolverAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaVariableResolverAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/tagext/JakartaBodyContentAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/jakarta/servlet/jsp/tagext/JakartaBodyContentAdapter.java
@@ -19,7 +19,8 @@ public class JakartaBodyContentAdapter extends BodyContent implements Adapted<ja
     private final javax.servlet.jsp.tagext.BodyContent delegate;
 
     public static BodyContent from(javax.servlet.jsp.tagext.BodyContent delegate) {
-        if (delegate instanceof JavaXBodyContentAdapter castDelegate) {
+        if (delegate instanceof JavaXBodyContentAdapter) {
+            JavaXBodyContentAdapter castDelegate = (JavaXBodyContentAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JakartaBodyContentAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/JavaXAdapters.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/JavaXAdapters.java
@@ -33,17 +33,23 @@ public class JavaXAdapters {
      * </ul>
      */
     public static Object asJavaXIfJakarta(Object delegate) {
-        if (delegate instanceof jakarta.servlet.ServletRequest cast) {
+        if (delegate instanceof jakarta.servlet.ServletRequest) {
+            jakarta.servlet.ServletRequest cast = (jakarta.servlet.ServletRequest) delegate;
             return asJavaX(cast);
-        } else if (delegate instanceof jakarta.servlet.ServletResponse cast) {
+        } else if (delegate instanceof jakarta.servlet.ServletResponse) {
+            jakarta.servlet.ServletResponse cast = (jakarta.servlet.ServletResponse) delegate;
             return asJavaX(cast);
-        } else if (delegate instanceof jakarta.servlet.ServletContext cast) {
+        } else if (delegate instanceof jakarta.servlet.ServletContext) {
+            jakarta.servlet.ServletContext cast = (jakarta.servlet.ServletContext) delegate;
             return asJavaX(cast);
-        } else if (delegate instanceof jakarta.servlet.Servlet cast) {
+        } else if (delegate instanceof jakarta.servlet.Servlet) {
+            jakarta.servlet.Servlet cast = (jakarta.servlet.Servlet) delegate;
             return asJavaX(cast);
-        } else if (delegate instanceof jakarta.servlet.Filter cast) {
+        } else if (delegate instanceof jakarta.servlet.Filter) {
+            jakarta.servlet.Filter cast = (jakarta.servlet.Filter) delegate;
             return asJavaX(cast);
-        } else if (delegate instanceof jakarta.servlet.http.HttpSession cast) {
+        } else if (delegate instanceof jakarta.servlet.http.HttpSession) {
+            jakarta.servlet.http.HttpSession cast = (jakarta.servlet.http.HttpSession) delegate;
             return asJavaX(cast);
         }
         return delegate;

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXELContextAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXELContextAdapter.java
@@ -24,7 +24,8 @@ public class JavaXELContextAdapter extends ELContext implements Adapted<jakarta.
     private final jakarta.el.ELContext delegate;
 
     public static ELContext from(jakarta.el.ELContext delegate) {
-        if (delegate instanceof JakartaELContextAdapter castDelegate) {
+        if (delegate instanceof JakartaELContextAdapter) {
+            JakartaELContextAdapter castDelegate = (JakartaELContextAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXELContextAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXELContextEventAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXELContextEventAdapter.java
@@ -14,7 +14,8 @@ public class JavaXELContextEventAdapter extends ELContextEvent implements Adapte
     private final jakarta.el.ELContextEvent delegate;
 
     public static ELContextEvent from(jakarta.el.ELContextEvent delegate) {
-        if (delegate instanceof JakartaELContextEventAdapter castDelegate) {
+        if (delegate instanceof JakartaELContextEventAdapter) {
+            JakartaELContextEventAdapter castDelegate = (JakartaELContextEventAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXELContextEventAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXELContextListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXELContextListenerAdapter.java
@@ -16,7 +16,8 @@ public class JavaXELContextListenerAdapter implements ELContextListener, Adapted
     private final jakarta.el.ELContextListener delegate;
 
     public static ELContextListener from(jakarta.el.ELContextListener delegate) {
-        if (delegate instanceof JakartaELContextListenerAdapter castDelegate) {
+        if (delegate instanceof JakartaELContextListenerAdapter) {
+            JakartaELContextListenerAdapter castDelegate = (JakartaELContextListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXELContextListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXEvaluationListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXEvaluationListenerAdapter.java
@@ -16,7 +16,8 @@ public class JavaXEvaluationListenerAdapter extends EvaluationListener implement
     private final jakarta.el.EvaluationListener delegate;
 
     public static EvaluationListener from(jakarta.el.EvaluationListener delegate) {
-        if (delegate instanceof JakartaEvaluationListenerAdapter castDelegate) {
+        if (delegate instanceof JakartaEvaluationListenerAdapter) {
+            JakartaEvaluationListenerAdapter castDelegate = (JakartaEvaluationListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXEvaluationListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXExpressionFactoryAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXExpressionFactoryAdapter.java
@@ -21,7 +21,8 @@ public class JavaXExpressionFactoryAdapter extends ExpressionFactory implements 
     private final jakarta.el.ExpressionFactory delegate;
 
     public static ExpressionFactory from(jakarta.el.ExpressionFactory delegate) {
-        if (delegate instanceof JakartaExpressionFactoryAdapter castDelegate) {
+        if (delegate instanceof JakartaExpressionFactoryAdapter) {
+            JakartaExpressionFactoryAdapter castDelegate = (JakartaExpressionFactoryAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXExpressionFactoryAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXFunctionMapperAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXFunctionMapperAdapter.java
@@ -15,7 +15,8 @@ public class JavaXFunctionMapperAdapter extends FunctionMapper implements Adapte
     private final jakarta.el.FunctionMapper delegate;
 
     public static FunctionMapper from(jakarta.el.FunctionMapper delegate) {
-        if (delegate instanceof JakartaFunctionMapperAdapter castDelegate) {
+        if (delegate instanceof JakartaFunctionMapperAdapter) {
+            JakartaFunctionMapperAdapter castDelegate = (JakartaFunctionMapperAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXFunctionMapperAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXImportHandlerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXImportHandlerAdapter.java
@@ -15,7 +15,8 @@ public class JavaXImportHandlerAdapter extends ImportHandler implements Adapted<
     private final jakarta.el.ImportHandler delegate;
 
     public static ImportHandler from(jakarta.el.ImportHandler delegate) {
-        if (delegate instanceof JakartaImportHandlerAdapter castDelegate) {
+        if (delegate instanceof JakartaImportHandlerAdapter) {
+            JakartaImportHandlerAdapter castDelegate = (JakartaImportHandlerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXImportHandlerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXMethodExpressionAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXMethodExpressionAdapter.java
@@ -17,7 +17,8 @@ public class JavaXMethodExpressionAdapter extends MethodExpression implements Ad
     private final jakarta.el.MethodExpression delegate;
 
     public static MethodExpression from(jakarta.el.MethodExpression delegate) {
-        if (delegate instanceof JakartaMethodExpressionAdapter castDelegate) {
+        if (delegate instanceof JakartaMethodExpressionAdapter) {
+            JakartaMethodExpressionAdapter castDelegate = (JakartaMethodExpressionAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXMethodExpressionAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXMethodInfoAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXMethodInfoAdapter.java
@@ -13,7 +13,8 @@ public class JavaXMethodInfoAdapter extends MethodInfo implements Adapted<jakart
     private final jakarta.el.MethodInfo delegate;
 
     public static MethodInfo from(jakarta.el.MethodInfo delegate) {
-        if (delegate instanceof JakartaMethodInfoAdapter castDelegate) {
+        if (delegate instanceof JakartaMethodInfoAdapter) {
+            JakartaMethodInfoAdapter castDelegate = (JakartaMethodInfoAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXMethodInfoAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXValueExpressionAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXValueExpressionAdapter.java
@@ -17,7 +17,8 @@ public class JavaXValueExpressionAdapter extends ValueExpression implements Adap
     private final jakarta.el.ValueExpression delegate;
 
     public static ValueExpression from(jakarta.el.ValueExpression delegate) {
-        if (delegate instanceof JakartaValueExpressionAdapter castDelegate) {
+        if (delegate instanceof JakartaValueExpressionAdapter) {
+            JakartaValueExpressionAdapter castDelegate = (JakartaValueExpressionAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXValueExpressionAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXValueReferenceAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXValueReferenceAdapter.java
@@ -13,7 +13,8 @@ public class JavaXValueReferenceAdapter extends ValueReference implements Adapte
     private final jakarta.el.ValueReference delegate;
 
     public static ValueReference from(jakarta.el.ValueReference delegate) {
-        if (delegate instanceof JakartaValueReferenceAdapter castDelegate) {
+        if (delegate instanceof JakartaValueReferenceAdapter) {
+            JakartaValueReferenceAdapter castDelegate = (JakartaValueReferenceAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXValueReferenceAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/el/JavaXVariableMapperAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/el/JavaXVariableMapperAdapter.java
@@ -16,7 +16,8 @@ public class JavaXVariableMapperAdapter extends VariableMapper implements Adapte
     private final jakarta.el.VariableMapper delegate;
 
     public static VariableMapper from(jakarta.el.VariableMapper delegate) {
-        if (delegate instanceof JakartaVariableMapperAdapter castDelegate) {
+        if (delegate instanceof JakartaVariableMapperAdapter) {
+            JakartaVariableMapperAdapter castDelegate = (JakartaVariableMapperAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXVariableMapperAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXAsyncContextAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXAsyncContextAdapter.java
@@ -22,7 +22,8 @@ public class JavaXAsyncContextAdapter implements AsyncContext, Adapted<jakarta.s
     private final jakarta.servlet.AsyncContext delegate;
 
     public static AsyncContext from(jakarta.servlet.AsyncContext delegate) {
-        if (delegate instanceof JakartaAsyncContextAdapter castDelegate) {
+        if (delegate instanceof JakartaAsyncContextAdapter) {
+            JakartaAsyncContextAdapter castDelegate = (JakartaAsyncContextAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXAsyncContextAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXAsyncEventAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXAsyncEventAdapter.java
@@ -18,7 +18,8 @@ public class JavaXAsyncEventAdapter extends AsyncEvent implements Adapted<jakart
     private final jakarta.servlet.AsyncEvent delegate;
 
     public static AsyncEvent from(jakarta.servlet.AsyncEvent delegate) {
-        if (delegate instanceof JakartaAsyncEventAdapter castDelegate) {
+        if (delegate instanceof JakartaAsyncEventAdapter) {
+            JakartaAsyncEventAdapter castDelegate = (JakartaAsyncEventAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXAsyncEventAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXAsyncListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXAsyncListenerAdapter.java
@@ -16,7 +16,8 @@ public class JavaXAsyncListenerAdapter implements AsyncListener, Adapted<jakarta
     private final jakarta.servlet.AsyncListener delegate;
 
     public static AsyncListener from(jakarta.servlet.AsyncListener delegate) {
-        if (delegate instanceof JakartaAsyncListenerAdapter castDelegate) {
+        if (delegate instanceof JakartaAsyncListenerAdapter) {
+            JakartaAsyncListenerAdapter castDelegate = (JakartaAsyncListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXAsyncListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXDynamicFilterRegistrationAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXDynamicFilterRegistrationAdapter.java
@@ -13,7 +13,8 @@ public class JavaXDynamicFilterRegistrationAdapter extends JavaXFilterRegistrati
     private final jakarta.servlet.FilterRegistration.Dynamic delegate;
 
     public static FilterRegistration.Dynamic from(jakarta.servlet.FilterRegistration.Dynamic delegate) {
-        if (delegate instanceof JakartaDynamicFilterRegistrationAdapter castDelegate) {
+        if (delegate instanceof JakartaDynamicFilterRegistrationAdapter) {
+            JakartaDynamicFilterRegistrationAdapter castDelegate = (JakartaDynamicFilterRegistrationAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXDynamicFilterRegistrationAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXDynamicServletRegistrationAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXDynamicServletRegistrationAdapter.java
@@ -18,7 +18,8 @@ public class JavaXDynamicServletRegistrationAdapter extends JavaXServletRegistra
     private final jakarta.servlet.ServletRegistration.Dynamic delegate;
 
     public static ServletRegistration.Dynamic from(jakarta.servlet.ServletRegistration.Dynamic delegate) {
-        if (delegate instanceof JakartaDynamicServletRegistrationAdapter castDelegate) {
+        if (delegate instanceof JakartaDynamicServletRegistrationAdapter) {
+            JakartaDynamicServletRegistrationAdapter castDelegate = (JakartaDynamicServletRegistrationAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXDynamicServletRegistrationAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXFilterAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXFilterAdapter.java
@@ -24,10 +24,12 @@ public class JavaXFilterAdapter implements Filter, Adapted<jakarta.servlet.Filte
     private final jakarta.servlet.Filter delegate;
 
     public static Filter from(jakarta.servlet.Filter delegate) {
-        if (delegate instanceof GenericFilter castDelegate) {
+        if (delegate instanceof GenericFilter) {
+            GenericFilter castDelegate = (GenericFilter) delegate;
             return JavaXGenericFilterAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaFilterAdapter castDelegate) {
+        if (delegate instanceof JakartaFilterAdapter) {
+            JakartaFilterAdapter castDelegate = (JakartaFilterAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXFilterAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXFilterChainAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXFilterChainAdapter.java
@@ -19,7 +19,8 @@ public class JavaXFilterChainAdapter implements FilterChain, Adapted<jakarta.ser
     private final jakarta.servlet.FilterChain delegate;
 
     public static FilterChain from(jakarta.servlet.FilterChain delegate) {
-        if (delegate instanceof JakartaFilterChainAdapter castDelegate) {
+        if (delegate instanceof JakartaFilterChainAdapter) {
+            JakartaFilterChainAdapter castDelegate = (JakartaFilterChainAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXFilterChainAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXFilterConfigAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXFilterConfigAdapter.java
@@ -17,7 +17,8 @@ public class JavaXFilterConfigAdapter implements FilterConfig, Adapted<jakarta.s
     private final jakarta.servlet.FilterConfig delegate;
 
     public static FilterConfig from(jakarta.servlet.FilterConfig delegate) {
-        if (delegate instanceof JakartaFilterConfigAdapter castDelegate) {
+        if (delegate instanceof JakartaFilterConfigAdapter) {
+            JakartaFilterConfigAdapter castDelegate = (JakartaFilterConfigAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXFilterConfigAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXFilterRegistrationAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXFilterRegistrationAdapter.java
@@ -16,10 +16,12 @@ public class JavaXFilterRegistrationAdapter extends JavaXRegistrationAdapter imp
     private final jakarta.servlet.FilterRegistration delegate;
 
     public static FilterRegistration from(jakarta.servlet.FilterRegistration delegate) {
-        if (delegate instanceof jakarta.servlet.FilterRegistration.Dynamic castDelegate) {
+        if (delegate instanceof jakarta.servlet.FilterRegistration.Dynamic) {
+            jakarta.servlet.FilterRegistration.Dynamic castDelegate = (jakarta.servlet.FilterRegistration.Dynamic) delegate;
             return JavaXDynamicFilterRegistrationAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaFilterRegistrationAdapter castDelegate) {
+        if (delegate instanceof JakartaFilterRegistrationAdapter) {
+            JakartaFilterRegistrationAdapter castDelegate = (JakartaFilterRegistrationAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXFilterRegistrationAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXGenericFilterAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXGenericFilterAdapter.java
@@ -25,10 +25,12 @@ public class JavaXGenericFilterAdapter extends GenericFilter implements Adapted<
     private final jakarta.servlet.GenericFilter delegate;
 
     public static javax.servlet.GenericFilter from(jakarta.servlet.GenericFilter delegate) {
-        if (delegate instanceof jakarta.servlet.http.HttpFilter castDelegate) {
+        if (delegate instanceof jakarta.servlet.http.HttpFilter) {
+            jakarta.servlet.http.HttpFilter castDelegate = (jakarta.servlet.http.HttpFilter) delegate;
             return JavaXHttpFilterAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaGenericFilterAdapter castDelegate) {
+        if (delegate instanceof JakartaGenericFilterAdapter) {
+            JakartaGenericFilterAdapter castDelegate = (JakartaGenericFilterAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXGenericFilterAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXGenericServletAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXGenericServletAdapter.java
@@ -24,10 +24,12 @@ public class JavaXGenericServletAdapter extends GenericServlet implements Adapte
     private final jakarta.servlet.GenericServlet delegate;
 
     public static javax.servlet.GenericServlet from(jakarta.servlet.GenericServlet delegate) {
-        if (delegate instanceof jakarta.servlet.http.HttpServlet castDelegate) {
+        if (delegate instanceof jakarta.servlet.http.HttpServlet) {
+            jakarta.servlet.http.HttpServlet castDelegate = (jakarta.servlet.http.HttpServlet) delegate;
             return JavaXHttpServletAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaGenericServletAdapter castDelegate) {
+        if (delegate instanceof JakartaGenericServletAdapter) {
+            JakartaGenericServletAdapter castDelegate = (JakartaGenericServletAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXGenericServletAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXHttpMethodConstraintElementAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXHttpMethodConstraintElementAdapter.java
@@ -15,7 +15,8 @@ public class JavaXHttpMethodConstraintElementAdapter extends HttpMethodConstrain
     private final jakarta.servlet.HttpMethodConstraintElement delegate;
 
     public static HttpMethodConstraintElement from(jakarta.servlet.HttpMethodConstraintElement delegate) {
-        if (delegate instanceof JakartaHttpMethodConstraintElementAdapter castDelegate) {
+        if (delegate instanceof JakartaHttpMethodConstraintElementAdapter) {
+            JakartaHttpMethodConstraintElementAdapter castDelegate = (JakartaHttpMethodConstraintElementAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXHttpMethodConstraintElementAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXMultipartConfigElementAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXMultipartConfigElementAdapter.java
@@ -14,7 +14,8 @@ public class JavaXMultipartConfigElementAdapter extends MultipartConfigElement i
     private final jakarta.servlet.MultipartConfigElement delegate;
 
     public static MultipartConfigElement from(jakarta.servlet.MultipartConfigElement delegate) {
-        if (delegate instanceof JakartaMultipartConfigElementAdapter castDelegate) {
+        if (delegate instanceof JakartaMultipartConfigElementAdapter) {
+            JakartaMultipartConfigElementAdapter castDelegate = (JakartaMultipartConfigElementAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXMultipartConfigElementAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXReadListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXReadListenerAdapter.java
@@ -15,7 +15,8 @@ public class JavaXReadListenerAdapter implements ReadListener, Adapted<jakarta.s
     private final jakarta.servlet.ReadListener delegate;
 
     public static ReadListener from(jakarta.servlet.ReadListener delegate) {
-        if (delegate instanceof JakartaReadListenerAdapter castDelegate) {
+        if (delegate instanceof JakartaReadListenerAdapter) {
+            JakartaReadListenerAdapter castDelegate = (JakartaReadListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXReadListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXRegistrationAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXRegistrationAdapter.java
@@ -16,13 +16,16 @@ public class JavaXRegistrationAdapter implements Registration, Adapted<jakarta.s
     private final jakarta.servlet.Registration delegate;
 
     public static Registration from(jakarta.servlet.Registration delegate) {
-        if (delegate instanceof jakarta.servlet.ServletRegistration castDelegate) {
+        if (delegate instanceof jakarta.servlet.ServletRegistration) {
+            jakarta.servlet.ServletRegistration castDelegate = (jakarta.servlet.ServletRegistration) delegate;
             return JavaXServletRegistrationAdapter.from(castDelegate);
         }
-        if (delegate instanceof jakarta.servlet.FilterRegistration castDelegate) {
+        if (delegate instanceof jakarta.servlet.FilterRegistration) {
+            jakarta.servlet.FilterRegistration castDelegate = (jakarta.servlet.FilterRegistration) delegate;
             return JavaXFilterRegistrationAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaRegistrationAdapter castDelegate) {
+        if (delegate instanceof JakartaRegistrationAdapter) {
+            JakartaRegistrationAdapter castDelegate = (JakartaRegistrationAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXRegistrationAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXRequestDispatcherAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXRequestDispatcherAdapter.java
@@ -18,7 +18,8 @@ public class JavaXRequestDispatcherAdapter implements RequestDispatcher, Adapted
     private final jakarta.servlet.RequestDispatcher delegate;
 
     public static RequestDispatcher from(jakarta.servlet.RequestDispatcher delegate) {
-        if (delegate instanceof JakartaRequestDispatcherAdapter castDelegate) {
+        if (delegate instanceof JakartaRequestDispatcherAdapter) {
+            JakartaRequestDispatcherAdapter castDelegate = (JakartaRequestDispatcherAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXRequestDispatcherAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletAdapter.java
@@ -21,10 +21,12 @@ public class JavaXServletAdapter implements Servlet, Adapted<jakarta.servlet.Ser
     private final jakarta.servlet.Servlet delegate;
 
     public static Servlet from(jakarta.servlet.Servlet delegate) {
-        if (delegate instanceof jakarta.servlet.GenericServlet castDelegate) {
+        if (delegate instanceof jakarta.servlet.GenericServlet) {
+            jakarta.servlet.GenericServlet castDelegate = (jakarta.servlet.GenericServlet) delegate;
             return JavaXGenericServletAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaServletAdapter castDelegate) {
+        if (delegate instanceof JakartaServletAdapter) {
+            JakartaServletAdapter castDelegate = (JakartaServletAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletConfigAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletConfigAdapter.java
@@ -17,7 +17,8 @@ public class JavaXServletConfigAdapter implements ServletConfig, Adapted<jakarta
     private final jakarta.servlet.ServletConfig delegate;
 
     public static ServletConfig from(jakarta.servlet.ServletConfig delegate) {
-        if (delegate instanceof JakartaServletConfigAdapter castDelegate) {
+        if (delegate instanceof JakartaServletConfigAdapter) {
+            JakartaServletConfigAdapter castDelegate = (JakartaServletConfigAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletConfigAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletContextAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletContextAdapter.java
@@ -40,7 +40,8 @@ public class JavaXServletContextAdapter implements ServletContext, Adapted<jakar
     private final jakarta.servlet.ServletContext delegate;
 
     public static ServletContext from(jakarta.servlet.ServletContext delegate) {
-        if (delegate instanceof JakartaServletContextAdapter castDelegate) {
+        if (delegate instanceof JakartaServletContextAdapter) {
+            JakartaServletContextAdapter castDelegate = (JakartaServletContextAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletContextAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletContextEventAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletContextEventAdapter.java
@@ -15,7 +15,8 @@ public class JavaXServletContextEventAdapter extends ServletContextEvent impleme
     private final jakarta.servlet.ServletContextEvent delegate;
 
     public static ServletContextEvent from(jakarta.servlet.ServletContextEvent delegate) {
-        if (delegate instanceof JakartaServletContextEventAdapter castDelegate) {
+        if (delegate instanceof JakartaServletContextEventAdapter) {
+            JakartaServletContextEventAdapter castDelegate = (JakartaServletContextEventAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletContextEventAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletContextListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletContextListenerAdapter.java
@@ -16,7 +16,8 @@ public class JavaXServletContextListenerAdapter implements ServletContextListene
     private final jakarta.servlet.ServletContextListener delegate;
 
     public static ServletContextListener from(jakarta.servlet.ServletContextListener delegate) {
-        if (delegate instanceof JakartaServletContextListenerAdapter castDelegate) {
+        if (delegate instanceof JakartaServletContextListenerAdapter) {
+            JakartaServletContextListenerAdapter castDelegate = (JakartaServletContextListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletContextListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletInputStreamAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletInputStreamAdapter.java
@@ -18,7 +18,8 @@ public class JavaXServletInputStreamAdapter extends ServletInputStream implement
     private final jakarta.servlet.ServletInputStream delegate;
 
     public static ServletInputStream from(jakarta.servlet.ServletInputStream delegate) {
-        if (delegate instanceof JakartaServletInputStreamAdapter castDelegate) {
+        if (delegate instanceof JakartaServletInputStreamAdapter) {
+            JakartaServletInputStreamAdapter castDelegate = (JakartaServletInputStreamAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletInputStreamAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletInputStreamAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletInputStreamAdapter.java
@@ -9,6 +9,8 @@ import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import static io.atlassian.util.adapter.util.WrapperUtil.applyIfNonNull;
 import static java.util.Objects.requireNonNull;
@@ -68,9 +70,21 @@ public class JavaXServletInputStreamAdapter extends ServletInputStream implement
         return delegate.skip(n);
     }
 
-    @Override
     public void skipNBytes(long n) throws IOException {
-        delegate.skipNBytes(n);
+        try {
+            Method skipNBytes = delegate.getClass().getMethod("skipNBytes", long.class);
+            skipNBytes.invoke(delegate, n);
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException("Could not find or invoke skipNBytes on delegate stream.", e);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            } else if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            } else {
+                throw new RuntimeException(e.getCause());
+            }
+        }
     }
 
     @Override

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletOutputStreamAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletOutputStreamAdapter.java
@@ -17,7 +17,8 @@ public class JavaXServletOutputStreamAdapter extends ServletOutputStream impleme
     private final jakarta.servlet.ServletOutputStream delegate;
 
     public static ServletOutputStream from(jakarta.servlet.ServletOutputStream delegate) {
-        if (delegate instanceof JakartaServletOutputStreamAdapter castDelegate) {
+        if (delegate instanceof JakartaServletOutputStreamAdapter) {
+            JakartaServletOutputStreamAdapter castDelegate = (JakartaServletOutputStreamAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletOutputStreamAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletRegistrationAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletRegistrationAdapter.java
@@ -15,10 +15,12 @@ public class JavaXServletRegistrationAdapter extends JavaXRegistrationAdapter im
     private final jakarta.servlet.ServletRegistration delegate;
 
     public static ServletRegistration from(jakarta.servlet.ServletRegistration delegate) {
-        if (delegate instanceof jakarta.servlet.ServletRegistration.Dynamic castDelegate) {
+        if (delegate instanceof jakarta.servlet.ServletRegistration.Dynamic) {
+            jakarta.servlet.ServletRegistration.Dynamic castDelegate = (jakarta.servlet.ServletRegistration.Dynamic) delegate;
             return JavaXDynamicServletRegistrationAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaServletRegistrationAdapter castDelegate) {
+        if (delegate instanceof JakartaServletRegistrationAdapter) {
+            JakartaServletRegistrationAdapter castDelegate = (JakartaServletRegistrationAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletRegistrationAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletRequestAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletRequestAdapter.java
@@ -31,13 +31,16 @@ public class JavaXServletRequestAdapter implements ServletRequest, Adapted<jakar
     private final jakarta.servlet.ServletRequest delegate;
 
     public static ServletRequest from(jakarta.servlet.ServletRequest delegate) {
-        if (delegate instanceof jakarta.servlet.http.HttpServletRequest castDelegate) {
+        if (delegate instanceof jakarta.servlet.http.HttpServletRequest) {
+            jakarta.servlet.http.HttpServletRequest castDelegate = (jakarta.servlet.http.HttpServletRequest) delegate;
             return JavaXHttpServletRequestAdapter.from(castDelegate);
         }
-        if (delegate instanceof jakarta.servlet.ServletRequestWrapper castDelegate) {
+        if (delegate instanceof jakarta.servlet.ServletRequestWrapper) {
+            jakarta.servlet.ServletRequestWrapper castDelegate = (jakarta.servlet.ServletRequestWrapper) delegate;
             return JavaXServletRequestWrapperAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaServletRequestAdapter castDelegate) {
+        if (delegate instanceof JakartaServletRequestAdapter) {
+            JakartaServletRequestAdapter castDelegate = (JakartaServletRequestAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletRequestAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletRequestWrapperAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletRequestWrapperAdapter.java
@@ -14,10 +14,12 @@ import static io.atlassian.util.adapter.util.WrapperUtil.applyIfNonNull;
 public class JavaXServletRequestWrapperAdapter extends ServletRequestWrapper implements Adapted<jakarta.servlet.ServletRequestWrapper> {
 
     public static ServletRequestWrapper from(jakarta.servlet.ServletRequestWrapper delegate) {
-        if (delegate instanceof jakarta.servlet.http.HttpServletRequestWrapper castDelegate) {
+        if (delegate instanceof jakarta.servlet.http.HttpServletRequestWrapper) {
+            jakarta.servlet.http.HttpServletRequestWrapper castDelegate = (jakarta.servlet.http.HttpServletRequestWrapper) delegate;
             return JavaXHttpServletRequestWrapperAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaServletRequestWrapperAdapter castDelegate) {
+        if (delegate instanceof JakartaServletRequestWrapperAdapter) {
+            JakartaServletRequestWrapperAdapter castDelegate = (JakartaServletRequestWrapperAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletRequestWrapperAdapter::new);
@@ -34,7 +36,8 @@ public class JavaXServletRequestWrapperAdapter extends ServletRequestWrapper imp
 
     @Override
     public boolean isWrapperFor(Class<?> wrappedType) {
-        if (getRequest() instanceof ServletRequestWrapper wrapper) {
+        if (getRequest() instanceof ServletRequestWrapper) {
+            ServletRequestWrapper wrapper = (ServletRequestWrapper) getRequest();
             return wrapper.isWrapperFor(wrappedType);
         }
         return false;
@@ -42,7 +45,8 @@ public class JavaXServletRequestWrapperAdapter extends ServletRequestWrapper imp
 
     @Override
     public boolean isWrapperFor(ServletRequest wrapped) {
-        if (getRequest() instanceof ServletRequestWrapper wrapper) {
+        if (getRequest() instanceof ServletRequestWrapper) {
+            ServletRequestWrapper wrapper = (ServletRequestWrapper) getRequest();
             return wrapper.isWrapperFor(wrapped);
         }
         return false;

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletResponseAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletResponseAdapter.java
@@ -19,10 +19,12 @@ public class JavaXServletResponseAdapter implements ServletResponse, Adapted<jak
     private final jakarta.servlet.ServletResponse delegate;
 
     public static ServletResponse from(jakarta.servlet.ServletResponse delegate) {
-        if (delegate instanceof jakarta.servlet.http.HttpServletResponse castDelegate) {
+        if (delegate instanceof jakarta.servlet.http.HttpServletResponse) {
+            jakarta.servlet.http.HttpServletResponse castDelegate = (jakarta.servlet.http.HttpServletResponse) delegate;
             return JavaXHttpServletResponseAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaServletResponseAdapter castDelegate) {
+        if (delegate instanceof JakartaServletResponseAdapter) {
+            JakartaServletResponseAdapter castDelegate = (JakartaServletResponseAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletResponseAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletSecurityElementAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXServletSecurityElementAdapter.java
@@ -18,7 +18,8 @@ public class JavaXServletSecurityElementAdapter extends ServletSecurityElement i
     private final jakarta.servlet.ServletSecurityElement delegate;
 
     public static ServletSecurityElement from(jakarta.servlet.ServletSecurityElement delegate) {
-        if (delegate instanceof JakartaServletSecurityElementAdapter castDelegate) {
+        if (delegate instanceof JakartaServletSecurityElementAdapter) {
+            JakartaServletSecurityElementAdapter castDelegate = (JakartaServletSecurityElementAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXServletSecurityElementAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXSessionCookieConfigAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXSessionCookieConfigAdapter.java
@@ -14,7 +14,8 @@ public class JavaXSessionCookieConfigAdapter implements SessionCookieConfig, Ada
     private final jakarta.servlet.SessionCookieConfig delegate;
 
     public static SessionCookieConfig from(jakarta.servlet.SessionCookieConfig delegate) {
-        if (delegate instanceof JakartaSessionCookieConfigAdapter castDelegate) {
+        if (delegate instanceof JakartaSessionCookieConfigAdapter) {
+            JakartaSessionCookieConfigAdapter castDelegate = (JakartaSessionCookieConfigAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXSessionCookieConfigAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXWriteListenerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/JavaXWriteListenerAdapter.java
@@ -14,7 +14,8 @@ public class JavaXWriteListenerAdapter implements WriteListener, Adapted<jakarta
     private final jakarta.servlet.WriteListener delegate;
 
     public static WriteListener from(jakarta.servlet.WriteListener delegate) {
-        if (delegate instanceof JakartaWriteListenerAdapter castDelegate) {
+        if (delegate instanceof JakartaWriteListenerAdapter) {
+            JakartaWriteListenerAdapter castDelegate = (JakartaWriteListenerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXWriteListenerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/descriptor/JavaXJspConfigDescriptorAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/descriptor/JavaXJspConfigDescriptorAdapter.java
@@ -18,7 +18,8 @@ public class JavaXJspConfigDescriptorAdapter implements JspConfigDescriptor, Ada
     private final jakarta.servlet.descriptor.JspConfigDescriptor delegate;
 
     public static JspConfigDescriptor from(jakarta.servlet.descriptor.JspConfigDescriptor delegate) {
-        if (delegate instanceof JakartaJspConfigDescriptorAdapter castDelegate) {
+        if (delegate instanceof JakartaJspConfigDescriptorAdapter) {
+            JakartaJspConfigDescriptorAdapter castDelegate = (JakartaJspConfigDescriptorAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXJspConfigDescriptorAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/descriptor/JavaXJspPropertyGroupDescriptorAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/descriptor/JavaXJspPropertyGroupDescriptorAdapter.java
@@ -15,7 +15,8 @@ public class JavaXJspPropertyGroupDescriptorAdapter implements JspPropertyGroupD
     private final jakarta.servlet.descriptor.JspPropertyGroupDescriptor delegate;
 
     public static JspPropertyGroupDescriptor from(jakarta.servlet.descriptor.JspPropertyGroupDescriptor delegate) {
-        if (delegate instanceof JakartaJspPropertyGroupDescriptorAdapter castDelegate) {
+        if (delegate instanceof JakartaJspPropertyGroupDescriptorAdapter) {
+            JakartaJspPropertyGroupDescriptorAdapter castDelegate = (JakartaJspPropertyGroupDescriptorAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXJspPropertyGroupDescriptorAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/descriptor/JavaXTaglibDescriptorAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/descriptor/JavaXTaglibDescriptorAdapter.java
@@ -14,7 +14,8 @@ public class JavaXTaglibDescriptorAdapter implements TaglibDescriptor, Adapted<j
     private final jakarta.servlet.descriptor.TaglibDescriptor delegate;
 
     public static TaglibDescriptor from(jakarta.servlet.descriptor.TaglibDescriptor delegate) {
-        if (delegate instanceof JakartaTaglibDescriptorAdapter castDelegate) {
+        if (delegate instanceof JakartaTaglibDescriptorAdapter) {
+            JakartaTaglibDescriptorAdapter castDelegate = (JakartaTaglibDescriptorAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXTaglibDescriptorAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXCookieAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXCookieAdapter.java
@@ -17,7 +17,8 @@ public class JavaXCookieAdapter extends Cookie implements Adapted<jakarta.servle
     private jakarta.servlet.http.Cookie delegate;
 
     public static Cookie from(jakarta.servlet.http.Cookie delegate) {
-        if (delegate instanceof JakartaCookieAdapter castDelegate) {
+        if (delegate instanceof JakartaCookieAdapter) {
+            JakartaCookieAdapter castDelegate = (JakartaCookieAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXCookieAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpFilterAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpFilterAdapter.java
@@ -24,7 +24,8 @@ public class JavaXHttpFilterAdapter extends HttpFilter implements Adapted<jakart
     private final jakarta.servlet.http.HttpFilter delegate;
 
     public static HttpFilter from(jakarta.servlet.http.HttpFilter delegate) {
-        if (delegate instanceof JakartaHttpFilterAdapter castDelegate) {
+        if (delegate instanceof JakartaHttpFilterAdapter) {
+            JakartaHttpFilterAdapter castDelegate = (JakartaHttpFilterAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXHttpFilterAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpServletAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpServletAdapter.java
@@ -23,7 +23,8 @@ public class JavaXHttpServletAdapter extends HttpServlet implements Adapted<jaka
     private final jakarta.servlet.http.HttpServlet delegate;
 
     public static HttpServlet from(jakarta.servlet.http.HttpServlet delegate) {
-        if (delegate instanceof JakartaHttpServletAdapter castDelegate) {
+        if (delegate instanceof JakartaHttpServletAdapter) {
+            JakartaHttpServletAdapter castDelegate = (JakartaHttpServletAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXHttpServletAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpServletMappingAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpServletMappingAdapter.java
@@ -15,7 +15,8 @@ public class JavaXHttpServletMappingAdapter implements HttpServletMapping, Adapt
     private final jakarta.servlet.http.HttpServletMapping delegate;
 
     public static HttpServletMapping from(jakarta.servlet.http.HttpServletMapping delegate) {
-        if (delegate instanceof JakartaHttpServletMappingAdapter castDelegate) {
+        if (delegate instanceof JakartaHttpServletMappingAdapter) {
+            JakartaHttpServletMappingAdapter castDelegate = (JakartaHttpServletMappingAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXHttpServletMappingAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpServletRequestAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpServletRequestAdapter.java
@@ -29,10 +29,12 @@ public class JavaXHttpServletRequestAdapter extends JavaXServletRequestAdapter i
     private final jakarta.servlet.http.HttpServletRequest delegate;
 
     public static HttpServletRequest from(jakarta.servlet.http.HttpServletRequest delegate) {
-        if (delegate instanceof jakarta.servlet.http.HttpServletRequestWrapper castDelegate) {
+        if (delegate instanceof jakarta.servlet.http.HttpServletRequestWrapper) {
+            jakarta.servlet.http.HttpServletRequestWrapper castDelegate = (jakarta.servlet.http.HttpServletRequestWrapper) delegate;
             return JavaXHttpServletRequestWrapperAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaHttpServletRequestAdapter castDelegate) {
+        if (delegate instanceof JakartaHttpServletRequestAdapter) {
+            JakartaHttpServletRequestAdapter castDelegate = (JakartaHttpServletRequestAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXHttpServletRequestAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpServletRequestWrapperAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpServletRequestWrapperAdapter.java
@@ -15,7 +15,8 @@ import static io.atlassian.util.adapter.util.WrapperUtil.applyIfNonNull;
 public class JavaXHttpServletRequestWrapperAdapter extends HttpServletRequestWrapper implements Adapted<jakarta.servlet.http.HttpServletRequestWrapper> {
 
     public static HttpServletRequestWrapper from(jakarta.servlet.http.HttpServletRequestWrapper delegate) {
-        if (delegate instanceof JakartaHttpServletRequestWrapperAdapter castDelegate) {
+        if (delegate instanceof JakartaHttpServletRequestWrapperAdapter) {
+            JakartaHttpServletRequestWrapperAdapter castDelegate = (JakartaHttpServletRequestWrapperAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXHttpServletRequestWrapperAdapter::new);
@@ -32,7 +33,8 @@ public class JavaXHttpServletRequestWrapperAdapter extends HttpServletRequestWra
 
     @Override
     public boolean isWrapperFor(Class<?> wrappedType) {
-        if (getRequest() instanceof ServletRequestWrapper wrapper) {
+        if (getRequest() instanceof ServletRequestWrapper) {
+            ServletRequestWrapper wrapper = (ServletRequestWrapper) getRequest();
             return wrapper.isWrapperFor(wrappedType);
         }
         return false;
@@ -40,7 +42,8 @@ public class JavaXHttpServletRequestWrapperAdapter extends HttpServletRequestWra
 
     @Override
     public boolean isWrapperFor(ServletRequest wrapped) {
-        if (getRequest() instanceof ServletRequestWrapper wrapper) {
+        if (getRequest() instanceof ServletRequestWrapper) {
+            ServletRequestWrapper wrapper = (ServletRequestWrapper) getRequest();
             return wrapper.isWrapperFor(wrapped);
         }
         return false;

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpServletResponseAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpServletResponseAdapter.java
@@ -19,7 +19,8 @@ public class JavaXHttpServletResponseAdapter extends JavaXServletResponseAdapter
     private final jakarta.servlet.http.HttpServletResponse delegate;
 
     public static HttpServletResponse from(jakarta.servlet.http.HttpServletResponse delegate) {
-        if (delegate instanceof JakartaHttpServletResponseAdapter castDelegate) {
+        if (delegate instanceof JakartaHttpServletResponseAdapter) {
+            JakartaHttpServletResponseAdapter castDelegate = (JakartaHttpServletResponseAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXHttpServletResponseAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpSessionAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpSessionAdapter.java
@@ -20,7 +20,8 @@ public class JavaXHttpSessionAdapter implements HttpSession, Adapted<jakarta.ser
     private final jakarta.servlet.http.HttpSession delegate;
 
     public static HttpSession from(jakarta.servlet.http.HttpSession delegate) {
-        if (delegate instanceof JakartaHttpSessionAdapter castDelegate) {
+        if (delegate instanceof JakartaHttpSessionAdapter) {
+            JakartaHttpSessionAdapter castDelegate = (JakartaHttpSessionAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXHttpSessionAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpUpgradeHandlerAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXHttpUpgradeHandlerAdapter.java
@@ -16,7 +16,8 @@ public class JavaXHttpUpgradeHandlerAdapter implements HttpUpgradeHandler, Adapt
     private final jakarta.servlet.http.HttpUpgradeHandler delegate;
 
     public static HttpUpgradeHandler from(jakarta.servlet.http.HttpUpgradeHandler delegate) {
-        if (delegate instanceof JakartaHttpUpgradeHandlerAdapter castDelegate) {
+        if (delegate instanceof JakartaHttpUpgradeHandlerAdapter) {
+            JakartaHttpUpgradeHandlerAdapter castDelegate = (JakartaHttpUpgradeHandlerAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXHttpUpgradeHandlerAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXPartAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXPartAdapter.java
@@ -17,7 +17,8 @@ public class JavaXPartAdapter implements Part, Adapted<jakarta.servlet.http.Part
     private final jakarta.servlet.http.Part delegate;
 
     public static Part from(jakarta.servlet.http.Part delegate) {
-        if (delegate instanceof JakartaPartAdapter castDelegate) {
+        if (delegate instanceof JakartaPartAdapter) {
+            JakartaPartAdapter castDelegate = (JakartaPartAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXPartAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXPushBuilderAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXPushBuilderAdapter.java
@@ -15,7 +15,8 @@ public class JavaXPushBuilderAdapter implements PushBuilder, Adapted<jakarta.ser
     private final jakarta.servlet.http.PushBuilder delegate;
 
     public static PushBuilder from(jakarta.servlet.http.PushBuilder delegate) {
-        if (delegate instanceof JakartaPushBuilderAdapter castDelegate) {
+        if (delegate instanceof JakartaPushBuilderAdapter) {
+            JakartaPushBuilderAdapter castDelegate = (JakartaPushBuilderAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXPushBuilderAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXWebConnectionAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/http/JavaXWebConnectionAdapter.java
@@ -18,7 +18,8 @@ public class JavaXWebConnectionAdapter implements WebConnection, Adapted<jakarta
     private final jakarta.servlet.http.WebConnection delegate;
 
     public static WebConnection from(jakarta.servlet.http.WebConnection delegate) {
-        if (delegate instanceof JakartaWebConnectionAdapter castDelegate) {
+        if (delegate instanceof JakartaWebConnectionAdapter) {
+            JakartaWebConnectionAdapter castDelegate = (JakartaWebConnectionAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXWebConnectionAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/JavaXJspApplicationContextAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/JavaXJspApplicationContextAdapter.java
@@ -19,7 +19,8 @@ public class JavaXJspApplicationContextAdapter implements JspApplicationContext,
     private final jakarta.servlet.jsp.JspApplicationContext delegate;
 
     public static JspApplicationContext from(jakarta.servlet.jsp.JspApplicationContext delegate) {
-        if (delegate instanceof JakartaJspApplicationContextAdapter castDelegate) {
+        if (delegate instanceof JakartaJspApplicationContextAdapter) {
+            JakartaJspApplicationContextAdapter castDelegate = (JakartaJspApplicationContextAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXJspApplicationContextAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/JavaXJspEngineInfoAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/JavaXJspEngineInfoAdapter.java
@@ -14,7 +14,8 @@ public class JavaXJspEngineInfoAdapter extends JspEngineInfo implements Adapted<
     private final jakarta.servlet.jsp.JspEngineInfo delegate;
 
     public static JspEngineInfo from(jakarta.servlet.jsp.JspEngineInfo delegate) {
-        if (delegate instanceof JakartaJspEngineInfoAdapter castDelegate) {
+        if (delegate instanceof JakartaJspEngineInfoAdapter) {
+            JakartaJspEngineInfoAdapter castDelegate = (JakartaJspEngineInfoAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXJspEngineInfoAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/JavaXJspFactoryAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/JavaXJspFactoryAdapter.java
@@ -22,7 +22,8 @@ public class JavaXJspFactoryAdapter extends JspFactory implements Adapted<jakart
     private final jakarta.servlet.jsp.JspFactory delegate;
 
     public static JspFactory from(jakarta.servlet.jsp.JspFactory delegate) {
-        if (delegate instanceof JakartaJspFactoryAdapter castDelegate) {
+        if (delegate instanceof JakartaJspFactoryAdapter) {
+            JakartaJspFactoryAdapter castDelegate = (JakartaJspFactoryAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXJspFactoryAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/JavaXJspWriterAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/JavaXJspWriterAdapter.java
@@ -16,10 +16,12 @@ public class JavaXJspWriterAdapter extends JspWriter implements Adapted<jakarta.
     private final jakarta.servlet.jsp.JspWriter delegate;
 
     public static JspWriter from(jakarta.servlet.jsp.JspWriter delegate) {
-        if (delegate instanceof jakarta.servlet.jsp.tagext.BodyContent castDelegate) {
+        if (delegate instanceof jakarta.servlet.jsp.tagext.BodyContent) {
+            jakarta.servlet.jsp.tagext.BodyContent castDelegate = (jakarta.servlet.jsp.tagext.BodyContent) delegate;
             return JavaXBodyContentAdapter.from(castDelegate);
         }
-        if (delegate instanceof JakartaJspWriterAdapter castDelegate) {
+        if (delegate instanceof JakartaJspWriterAdapter) {
+            JakartaJspWriterAdapter castDelegate = (JakartaJspWriterAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXJspWriterAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/JavaXPageContextAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/JavaXPageContextAdapter.java
@@ -35,7 +35,8 @@ public class JavaXPageContextAdapter extends PageContext implements Adapted<jaka
     private final jakarta.servlet.jsp.PageContext delegate;
 
     public static PageContext from(jakarta.servlet.jsp.PageContext delegate) {
-        if (delegate instanceof JakartaPageContextAdapter castDelegate) {
+        if (delegate instanceof JakartaPageContextAdapter) {
+            JakartaPageContextAdapter castDelegate = (JakartaPageContextAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXPageContextAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/el/JavaXExpressionAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/el/JavaXExpressionAdapter.java
@@ -17,7 +17,8 @@ public class JavaXExpressionAdapter extends Expression implements Adapted<jakart
     private final jakarta.servlet.jsp.el.Expression delegate;
 
     public static Expression from(jakarta.servlet.jsp.el.Expression delegate) {
-        if (delegate instanceof JakartaExpressionAdapter castDelegate) {
+        if (delegate instanceof JakartaExpressionAdapter) {
+            JakartaExpressionAdapter castDelegate = (JakartaExpressionAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXExpressionAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/el/JavaXExpressionEvaluatorAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/el/JavaXExpressionEvaluatorAdapter.java
@@ -20,7 +20,8 @@ public class JavaXExpressionEvaluatorAdapter extends ExpressionEvaluator impleme
     private final jakarta.servlet.jsp.el.ExpressionEvaluator delegate;
 
     public static ExpressionEvaluator from(jakarta.servlet.jsp.el.ExpressionEvaluator delegate) {
-        if (delegate instanceof JakartaExpressionEvaluatorAdapter castDelegate) {
+        if (delegate instanceof JakartaExpressionEvaluatorAdapter) {
+            JakartaExpressionEvaluatorAdapter castDelegate = (JakartaExpressionEvaluatorAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXExpressionEvaluatorAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/el/JavaXFunctionMapperAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/el/JavaXFunctionMapperAdapter.java
@@ -15,7 +15,8 @@ public class JavaXFunctionMapperAdapter implements FunctionMapper, Adapted<jakar
     private final jakarta.servlet.jsp.el.FunctionMapper delegate;
 
     public static FunctionMapper from(jakarta.servlet.jsp.el.FunctionMapper delegate) {
-        if (delegate instanceof JakartaFunctionMapperAdapter castDelegate) {
+        if (delegate instanceof JakartaFunctionMapperAdapter) {
+            JakartaFunctionMapperAdapter castDelegate = (JakartaFunctionMapperAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXFunctionMapperAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/el/JavaXVariableResolverAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/el/JavaXVariableResolverAdapter.java
@@ -15,7 +15,8 @@ public class JavaXVariableResolverAdapter implements VariableResolver, Adapted<j
     private final jakarta.servlet.jsp.el.VariableResolver delegate;
 
     public static VariableResolver from(jakarta.servlet.jsp.el.VariableResolver delegate) {
-        if (delegate instanceof JakartaVariableResolverAdapter castDelegate) {
+        if (delegate instanceof JakartaVariableResolverAdapter) {
+            JakartaVariableResolverAdapter castDelegate = (JakartaVariableResolverAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXVariableResolverAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/tagext/JavaXBodyContentAdapter.java
+++ b/src/main/java/io/atlassian/util/adapter/javax/servlet/jsp/tagext/JavaXBodyContentAdapter.java
@@ -19,7 +19,8 @@ public class JavaXBodyContentAdapter extends BodyContent implements Adapted<jaka
     private final jakarta.servlet.jsp.tagext.BodyContent delegate;
 
     public static BodyContent from(jakarta.servlet.jsp.tagext.BodyContent delegate) {
-        if (delegate instanceof JakartaBodyContentAdapter castDelegate) {
+        if (delegate instanceof JakartaBodyContentAdapter) {
+            JakartaBodyContentAdapter castDelegate = (JakartaBodyContentAdapter) delegate;
             return castDelegate.getDelegate();
         }
         return applyIfNonNull(delegate, JavaXBodyContentAdapter::new);

--- a/src/main/java/io/atlassian/util/adapter/util/WrapperUtil.java
+++ b/src/main/java/io/atlassian/util/adapter/util/WrapperUtil.java
@@ -8,6 +8,8 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
 
 public class WrapperUtil {
 
@@ -27,7 +29,7 @@ public class WrapperUtil {
         if (delegates == null) {
             return null;
         }
-        return delegates.stream().map(delegate -> applyIfNonNull(delegate, wrapper)).toList();
+        return delegates.stream().map(delegate -> applyIfNonNull(delegate, wrapper)).collect(Collectors.toList());
     }
 
     public static <T> T[] enumerationToArray(Enumeration<T> enumeration, Class<T> clazz) {

--- a/src/test/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletRequestWrapperAdapterTest.java
+++ b/src/test/java/io/atlassian/util/adapter/jakarta/servlet/JakartaServletRequestWrapperAdapterTest.java
@@ -102,10 +102,12 @@ class JakartaServletRequestWrapperAdapterTest {
      * Mimic unwrapping logic used in certain utility methods in a Jakarta environment.
      */
     static CustomJakartaServletRequestWrapper unwrapCustomRequest(ServletRequest request) {
-        if (request instanceof CustomJakartaServletRequestWrapper custom) {
+        if (request instanceof CustomJakartaServletRequestWrapper) {
+            CustomJakartaServletRequestWrapper custom = (CustomJakartaServletRequestWrapper) request;
             return custom;
         }
-        if (request instanceof ServletRequestWrapper wrapped) {
+        if (request instanceof ServletRequestWrapper) {
+            ServletRequestWrapper wrapped = (ServletRequestWrapper) request;
             return unwrapCustomRequest(wrapped.getRequest());
         }
         return null;
@@ -115,10 +117,12 @@ class JakartaServletRequestWrapperAdapterTest {
      * Mimic unwrapping logic used in certain utility methods in a JavaX environment.
      */
     static CustomJavaXServletRequestWrapper unwrapCustomRequest(javax.servlet.ServletRequest request) {
-        if (request instanceof CustomJavaXServletRequestWrapper custom) {
+        if (request instanceof CustomJavaXServletRequestWrapper) {
+            CustomJavaXServletRequestWrapper custom = (CustomJavaXServletRequestWrapper) request;
             return custom;
         }
-        if (request instanceof javax.servlet.ServletRequestWrapper wrapped) {
+        if (request instanceof javax.servlet.ServletRequestWrapper) {
+            javax.servlet.ServletRequestWrapper wrapped = (javax.servlet.ServletRequestWrapper) request;
             return unwrapCustomRequest(wrapped.getRequest());
         }
         return null;

--- a/src/test/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletRequestWrapperAdapterTest.java
+++ b/src/test/java/io/atlassian/util/adapter/jakarta/servlet/http/JakartaHttpServletRequestWrapperAdapterTest.java
@@ -110,10 +110,12 @@ class JakartaHttpServletRequestWrapperAdapterTest {
      * Mimic unwrapping logic used in certain utility methods in a Jakarta environment.
      */
     static CustomJakartaServletRequestWrapper unwrapCustomRequest(HttpServletRequest request) {
-        if (request instanceof CustomJakartaServletRequestWrapper custom) {
+        if (request instanceof CustomJakartaServletRequestWrapper) {
+            CustomJakartaServletRequestWrapper custom = (CustomJakartaServletRequestWrapper) request;
             return custom;
         }
-        if (request instanceof HttpServletRequestWrapper wrapped) {
+        if (request instanceof HttpServletRequestWrapper) {
+            HttpServletRequestWrapper wrapped = (HttpServletRequestWrapper) request;
             return unwrapCustomRequest((HttpServletRequest) wrapped.getRequest());
         }
         return null;
@@ -123,10 +125,12 @@ class JakartaHttpServletRequestWrapperAdapterTest {
      * Mimic unwrapping logic used in certain utility methods in a JavaX environment.
      */
     static CustomJavaXServletRequestWrapper unwrapCustomRequest(javax.servlet.http.HttpServletRequest request) {
-        if (request instanceof CustomJavaXServletRequestWrapper custom) {
+        if (request instanceof CustomJavaXServletRequestWrapper) {
+            CustomJavaXServletRequestWrapper custom = (CustomJavaXServletRequestWrapper) request;
             return custom;
         }
-        if (request instanceof javax.servlet.http.HttpServletRequestWrapper wrapped) {
+        if (request instanceof javax.servlet.http.HttpServletRequestWrapper) {
+            javax.servlet.http.HttpServletRequestWrapper wrapped = (javax.servlet.http.HttpServletRequestWrapper) request;
             return unwrapCustomRequest((javax.servlet.http.HttpServletRequest) wrapped.getRequest());
         }
         return null;


### PR DESCRIPTION
@kusalk This is the PR I mentioned for making the adapter library compatible with Java 11.

I've split it into separate commits to make it easier to find the interesting changes.
The bulk of the changes is caused by automatic refactoring of the pattern-match instanceof operators used in all of the adapter classes.  That's the first commit and relatively boring 🤷. The other commits might be more interesting to review, especially the one with the `skipNBytes` implementations. Let me know what you think about that approach.